### PR TITLE
Adding support for subregister fields

### DIFF
--- a/include/CoreGen/CoreGenBackend/CoreGenReg.h
+++ b/include/CoreGen/CoreGenBackend/CoreGenReg.h
@@ -25,6 +25,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <tuple>
 
 #include "CoreGen/CoreGenBackend/CoreGenErrno.h"
 #include "CoreGen/CoreGenBackend/CoreGenNode.h"
@@ -45,6 +46,10 @@ private:
   uint32_t attrs;         ///< CoreGenReg: Register Attributes
 
   std::vector<uint64_t> fixedVals;    ///< CoreGenReg: Fixed Value Vector
+  std::vector<std::tuple< std::string,  // Subregister name
+                          unsigned,     // Subregister start bit
+                          unsigned>     // Subregister end bit
+                            > SubRegs; ///< CoreGenReg: Subregister encodings
 
 public:
   /// CoreGenReg: Register Attributes
@@ -108,6 +113,15 @@ public:
   /// Retrieve the register attributes
   uint32_t GetAttrs() { return attrs; }
 
+  /// Retrieve the number of subregisters
+  unsigned GetNumSubRegs() { return SubRegs.size(); }
+
+  /// Retrieve the target subregister data
+  bool GetSubReg( unsigned Idx,
+                  std::string &Name,
+                  unsigned &Start,
+                  unsigned &End );
+
   /// Retrieve the register pseudo name
   std::string GetPseudoName();
 
@@ -128,6 +142,9 @@ public:
 
   /// Set the register pseudo name
   bool SetPseudoName( std::string PseudoName );
+
+  /// Insert a new subregister
+  bool InsertSubReg( std::string Name, unsigned Start, unsigned End );
 
   /// Default destructor
   ~CoreGenReg();

--- a/src/CoreGenBackend/CoreGenReg.cpp
+++ b/src/CoreGenBackend/CoreGenReg.cpp
@@ -148,7 +148,7 @@ bool CoreGenReg::SetFixedVals( std::vector<uint64_t> FixedVals ){
     return false;
   }
   isFixedValue = true;
-  for( int i=0; i<FixedVals.size(); i++ ){
+  for( unsigned i=0; i<FixedVals.size(); i++ ){
     fixedVals.push_back(FixedVals[i]);
   }
   return true;
@@ -170,6 +170,39 @@ bool CoreGenReg::GetFixedVals( std::vector<uint64_t> &FixedVals ){
     return true;
   }
   return false;
+}
+
+bool CoreGenReg::GetSubReg( unsigned Idx,
+                            std::string &Name,
+                            unsigned &Start,
+                            unsigned &End ){
+  if( Idx > (SubRegs.size()-1) ){
+    Errno->SetError(CGERR_ERROR, "Subregister index out of bound: "
+                    + std::to_string(Idx ) );
+    return false;
+  }
+
+  // retrieve all the data
+  Name  = std::get<0>(SubRegs[Idx]);
+  Start = std::get<1>(SubRegs[Idx]);
+  End   = std::get<2>(SubRegs[Idx]);
+
+  return true;
+}
+
+bool CoreGenReg::InsertSubReg( std::string Name, unsigned Start, unsigned End ){
+  if( Name.length() == 0 ){
+    Errno->SetError(CGERR_ERROR, "Subregister name is null" );
+    return false;
+  }else if( End == 0 ){
+    Errno->SetError(CGERR_ERROR, "Subregister end bit cannot be 0" );
+    return false;
+  }else if( End <= Start ){
+    Errno->SetError(CGERR_ERROR, "Subregister start and/or end bits out of range" );
+    return false;
+  }
+  SubRegs.push_back(std::tuple<std::string,unsigned,unsigned>(Name,Start,End));
+  return true;
 }
 
 CoreGenReg::~CoreGenReg() {

--- a/src/CoreGenBackend/CoreGenReg.cpp
+++ b/src/CoreGenBackend/CoreGenReg.cpp
@@ -200,6 +200,9 @@ bool CoreGenReg::InsertSubReg( std::string Name, unsigned Start, unsigned End ){
   }else if( End <= Start ){
     Errno->SetError(CGERR_ERROR, "Subregister start and/or end bits out of range" );
     return false;
+  }else if( (int)(End) >= width ){
+    Errno->SetError(CGERR_ERROR, "Subregister end bit beyond register width" );
+    return false;
   }
   SubRegs.push_back(std::tuple<std::string,unsigned,unsigned>(Name,Start,End));
   return true;

--- a/test/Yaml/Reader/MissingData/TEST36.yaml
+++ b/test/Yaml/Reader/MissingData/TEST36.yaml
@@ -1,0 +1,3143 @@
+ProjectInfo:
+  - ProjectName: TEST72
+    ProjectRoot: ./
+    ProjectType: unknown
+    ChiselMajorVersion: 3
+    ChiselMinorVersion: 0
+Registers:
+  - RegName: TEST72.0.reg
+    Width: 64
+    Index: 0
+    PseudoName: pseudoreg.0
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+    SubRegs:
+      - SubReg: 
+        StartBit: 0
+        EndBit: 31
+      - SubReg: SUBREG1
+        StartBit: 32
+        EndBit: 63
+  - RegName: TEST72.1.reg
+    Width: 64
+    Index: 1
+    PseudoName: pseudoreg.1
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.2.reg
+    Width: 64
+    Index: 2
+    PseudoName: pseudoreg.2
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.3.reg
+    Width: 64
+    Index: 3
+    PseudoName: pseudoreg.3
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.4.reg
+    Width: 64
+    Index: 4
+    PseudoName: pseudoreg.4
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.5.reg
+    Width: 64
+    Index: 5
+    PseudoName: pseudoreg.5
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.6.reg
+    Width: 64
+    Index: 6
+    PseudoName: pseudoreg.6
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.7.reg
+    Width: 64
+    Index: 7
+    PseudoName: pseudoreg.7
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.8.reg
+    Width: 64
+    Index: 8
+    PseudoName: pseudoreg.8
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.9.reg
+    Width: 64
+    Index: 9
+    PseudoName: pseudoreg.9
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.10.reg
+    Width: 64
+    Index: 10
+    PseudoName: pseudoreg.10
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.11.reg
+    Width: 64
+    Index: 11
+    PseudoName: pseudoreg.11
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.12.reg
+    Width: 64
+    Index: 12
+    PseudoName: pseudoreg.12
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.13.reg
+    Width: 64
+    Index: 13
+    PseudoName: pseudoreg.13
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.14.reg
+    Width: 64
+    Index: 14
+    PseudoName: pseudoreg.14
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.15.reg
+    Width: 64
+    Index: 15
+    PseudoName: pseudoreg.15
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.16.reg
+    Width: 64
+    Index: 16
+    PseudoName: pseudoreg.16
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.17.reg
+    Width: 64
+    Index: 17
+    PseudoName: pseudoreg.17
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.18.reg
+    Width: 64
+    Index: 18
+    PseudoName: pseudoreg.18
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.19.reg
+    Width: 64
+    Index: 19
+    PseudoName: pseudoreg.19
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.20.reg
+    Width: 64
+    Index: 20
+    PseudoName: pseudoreg.20
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.21.reg
+    Width: 64
+    Index: 21
+    PseudoName: pseudoreg.21
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.22.reg
+    Width: 64
+    Index: 22
+    PseudoName: pseudoreg.22
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.23.reg
+    Width: 64
+    Index: 23
+    PseudoName: pseudoreg.23
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.24.reg
+    Width: 64
+    Index: 24
+    PseudoName: pseudoreg.24
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.25.reg
+    Width: 64
+    Index: 25
+    PseudoName: pseudoreg.25
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.26.reg
+    Width: 64
+    Index: 26
+    PseudoName: pseudoreg.26
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.27.reg
+    Width: 64
+    Index: 27
+    PseudoName: pseudoreg.27
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.28.reg
+    Width: 64
+    Index: 28
+    PseudoName: pseudoreg.28
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.29.reg
+    Width: 64
+    Index: 29
+    PseudoName: pseudoreg.29
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.30.reg
+    Width: 64
+    Index: 30
+    PseudoName: pseudoreg.30
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.31.reg
+    Width: 64
+    Index: 31
+    PseudoName: pseudoreg.31
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.32.reg
+    Width: 64
+    Index: 32
+    PseudoName: pseudoreg.32
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.33.reg
+    Width: 64
+    Index: 33
+    PseudoName: pseudoreg.33
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.34.reg
+    Width: 64
+    Index: 34
+    PseudoName: pseudoreg.34
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.35.reg
+    Width: 64
+    Index: 35
+    PseudoName: pseudoreg.35
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.36.reg
+    Width: 64
+    Index: 36
+    PseudoName: pseudoreg.36
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.37.reg
+    Width: 64
+    Index: 37
+    PseudoName: pseudoreg.37
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.38.reg
+    Width: 64
+    Index: 38
+    PseudoName: pseudoreg.38
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.39.reg
+    Width: 64
+    Index: 39
+    PseudoName: pseudoreg.39
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.40.reg
+    Width: 64
+    Index: 40
+    PseudoName: pseudoreg.40
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.41.reg
+    Width: 64
+    Index: 41
+    PseudoName: pseudoreg.41
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.42.reg
+    Width: 64
+    Index: 42
+    PseudoName: pseudoreg.42
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.43.reg
+    Width: 64
+    Index: 43
+    PseudoName: pseudoreg.43
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.44.reg
+    Width: 64
+    Index: 44
+    PseudoName: pseudoreg.44
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.45.reg
+    Width: 64
+    Index: 45
+    PseudoName: pseudoreg.45
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.46.reg
+    Width: 64
+    Index: 46
+    PseudoName: pseudoreg.46
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.47.reg
+    Width: 64
+    Index: 47
+    PseudoName: pseudoreg.47
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.48.reg
+    Width: 64
+    Index: 48
+    PseudoName: pseudoreg.48
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.49.reg
+    Width: 64
+    Index: 49
+    PseudoName: pseudoreg.49
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.50.reg
+    Width: 64
+    Index: 50
+    PseudoName: pseudoreg.50
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.51.reg
+    Width: 64
+    Index: 51
+    PseudoName: pseudoreg.51
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.52.reg
+    Width: 64
+    Index: 52
+    PseudoName: pseudoreg.52
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.53.reg
+    Width: 64
+    Index: 53
+    PseudoName: pseudoreg.53
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.54.reg
+    Width: 64
+    Index: 54
+    PseudoName: pseudoreg.54
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.55.reg
+    Width: 64
+    Index: 55
+    PseudoName: pseudoreg.55
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.56.reg
+    Width: 64
+    Index: 56
+    PseudoName: pseudoreg.56
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.57.reg
+    Width: 64
+    Index: 57
+    PseudoName: pseudoreg.57
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.58.reg
+    Width: 64
+    Index: 58
+    PseudoName: pseudoreg.58
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.59.reg
+    Width: 64
+    Index: 59
+    PseudoName: pseudoreg.59
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.60.reg
+    Width: 64
+    Index: 60
+    PseudoName: pseudoreg.60
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.61.reg
+    Width: 64
+    Index: 61
+    PseudoName: pseudoreg.61
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.62.reg
+    Width: 64
+    Index: 62
+    PseudoName: pseudoreg.62
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.63.reg
+    Width: 64
+    Index: 63
+    PseudoName: pseudoreg.63
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.64.reg
+    Width: 64
+    Index: 64
+    PseudoName: pseudoreg.64
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.65.reg
+    Width: 64
+    Index: 65
+    PseudoName: pseudoreg.65
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.66.reg
+    Width: 64
+    Index: 66
+    PseudoName: pseudoreg.66
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.67.reg
+    Width: 64
+    Index: 67
+    PseudoName: pseudoreg.67
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.68.reg
+    Width: 64
+    Index: 68
+    PseudoName: pseudoreg.68
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.69.reg
+    Width: 64
+    Index: 69
+    PseudoName: pseudoreg.69
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.70.reg
+    Width: 64
+    Index: 70
+    PseudoName: pseudoreg.70
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.71.reg
+    Width: 64
+    Index: 71
+    PseudoName: pseudoreg.71
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.0.csr
+    Width: 64
+    Index: 0
+    PseudoName: csr.0
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.1.csr
+    Width: 64
+    Index: 1
+    PseudoName: csr.1
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.2.csr
+    Width: 64
+    Index: 2
+    PseudoName: csr.2
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.3.csr
+    Width: 64
+    Index: 3
+    PseudoName: csr.3
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.4.csr
+    Width: 64
+    Index: 4
+    PseudoName: csr.4
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.5.csr
+    Width: 64
+    Index: 5
+    PseudoName: csr.5
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.6.csr
+    Width: 64
+    Index: 6
+    PseudoName: csr.6
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.7.csr
+    Width: 64
+    Index: 7
+    PseudoName: csr.7
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.8.csr
+    Width: 64
+    Index: 8
+    PseudoName: csr.8
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.9.csr
+    Width: 64
+    Index: 9
+    PseudoName: csr.9
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.10.csr
+    Width: 64
+    Index: 10
+    PseudoName: csr.10
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.11.csr
+    Width: 64
+    Index: 11
+    PseudoName: csr.11
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.12.csr
+    Width: 64
+    Index: 12
+    PseudoName: csr.12
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.13.csr
+    Width: 64
+    Index: 13
+    PseudoName: csr.13
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.14.csr
+    Width: 64
+    Index: 14
+    PseudoName: csr.14
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.15.csr
+    Width: 64
+    Index: 15
+    PseudoName: csr.15
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.16.csr
+    Width: 64
+    Index: 16
+    PseudoName: csr.16
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.17.csr
+    Width: 64
+    Index: 17
+    PseudoName: csr.17
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.18.csr
+    Width: 64
+    Index: 18
+    PseudoName: csr.18
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.19.csr
+    Width: 64
+    Index: 19
+    PseudoName: csr.19
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.20.csr
+    Width: 64
+    Index: 20
+    PseudoName: csr.20
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.21.csr
+    Width: 64
+    Index: 21
+    PseudoName: csr.21
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.22.csr
+    Width: 64
+    Index: 22
+    PseudoName: csr.22
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.23.csr
+    Width: 64
+    Index: 23
+    PseudoName: csr.23
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.24.csr
+    Width: 64
+    Index: 24
+    PseudoName: csr.24
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.25.csr
+    Width: 64
+    Index: 25
+    PseudoName: csr.25
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.26.csr
+    Width: 64
+    Index: 26
+    PseudoName: csr.26
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.27.csr
+    Width: 64
+    Index: 27
+    PseudoName: csr.27
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.28.csr
+    Width: 64
+    Index: 28
+    PseudoName: csr.28
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.29.csr
+    Width: 64
+    Index: 29
+    PseudoName: csr.29
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.30.csr
+    Width: 64
+    Index: 30
+    PseudoName: csr.30
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.31.csr
+    Width: 64
+    Index: 31
+    PseudoName: csr.31
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.32.csr
+    Width: 64
+    Index: 32
+    PseudoName: csr.32
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.33.csr
+    Width: 64
+    Index: 33
+    PseudoName: csr.33
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.34.csr
+    Width: 64
+    Index: 34
+    PseudoName: csr.34
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.35.csr
+    Width: 64
+    Index: 35
+    PseudoName: csr.35
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.36.csr
+    Width: 64
+    Index: 36
+    PseudoName: csr.36
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.37.csr
+    Width: 64
+    Index: 37
+    PseudoName: csr.37
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.38.csr
+    Width: 64
+    Index: 38
+    PseudoName: csr.38
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.39.csr
+    Width: 64
+    Index: 39
+    PseudoName: csr.39
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.40.csr
+    Width: 64
+    Index: 40
+    PseudoName: csr.40
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.41.csr
+    Width: 64
+    Index: 41
+    PseudoName: csr.41
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.42.csr
+    Width: 64
+    Index: 42
+    PseudoName: csr.42
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.43.csr
+    Width: 64
+    Index: 43
+    PseudoName: csr.43
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.44.csr
+    Width: 64
+    Index: 44
+    PseudoName: csr.44
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.45.csr
+    Width: 64
+    Index: 45
+    PseudoName: csr.45
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.46.csr
+    Width: 64
+    Index: 46
+    PseudoName: csr.46
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.47.csr
+    Width: 64
+    Index: 47
+    PseudoName: csr.47
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.48.csr
+    Width: 64
+    Index: 48
+    PseudoName: csr.48
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.49.csr
+    Width: 64
+    Index: 49
+    PseudoName: csr.49
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.50.csr
+    Width: 64
+    Index: 50
+    PseudoName: csr.50
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.51.csr
+    Width: 64
+    Index: 51
+    PseudoName: csr.51
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.52.csr
+    Width: 64
+    Index: 52
+    PseudoName: csr.52
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.53.csr
+    Width: 64
+    Index: 53
+    PseudoName: csr.53
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.54.csr
+    Width: 64
+    Index: 54
+    PseudoName: csr.54
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.55.csr
+    Width: 64
+    Index: 55
+    PseudoName: csr.55
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.56.csr
+    Width: 64
+    Index: 56
+    PseudoName: csr.56
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.57.csr
+    Width: 64
+    Index: 57
+    PseudoName: csr.57
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.58.csr
+    Width: 64
+    Index: 58
+    PseudoName: csr.58
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.59.csr
+    Width: 64
+    Index: 59
+    PseudoName: csr.59
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.60.csr
+    Width: 64
+    Index: 60
+    PseudoName: csr.60
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.61.csr
+    Width: 64
+    Index: 61
+    PseudoName: csr.61
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.62.csr
+    Width: 64
+    Index: 62
+    PseudoName: csr.62
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.63.csr
+    Width: 64
+    Index: 63
+    PseudoName: csr.63
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.64.csr
+    Width: 64
+    Index: 64
+    PseudoName: csr.64
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.65.csr
+    Width: 64
+    Index: 65
+    PseudoName: csr.65
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.66.csr
+    Width: 64
+    Index: 66
+    PseudoName: csr.66
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.67.csr
+    Width: 64
+    Index: 67
+    PseudoName: csr.67
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.68.csr
+    Width: 64
+    Index: 68
+    PseudoName: csr.68
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.69.csr
+    Width: 64
+    Index: 69
+    PseudoName: csr.69
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.70.csr
+    Width: 64
+    Index: 70
+    PseudoName: csr.70
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.71.csr
+    Width: 64
+    Index: 71
+    PseudoName: csr.71
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+RegClasses:
+  - RegisterClassName: TEST72.regclass
+    Registers:
+      - TEST72.0.reg
+      - TEST72.1.reg
+      - TEST72.2.reg
+      - TEST72.3.reg
+      - TEST72.4.reg
+      - TEST72.5.reg
+      - TEST72.6.reg
+      - TEST72.7.reg
+      - TEST72.8.reg
+      - TEST72.9.reg
+      - TEST72.10.reg
+      - TEST72.11.reg
+      - TEST72.12.reg
+      - TEST72.13.reg
+      - TEST72.14.reg
+      - TEST72.15.reg
+      - TEST72.16.reg
+      - TEST72.17.reg
+      - TEST72.18.reg
+      - TEST72.19.reg
+      - TEST72.20.reg
+      - TEST72.21.reg
+      - TEST72.22.reg
+      - TEST72.23.reg
+      - TEST72.24.reg
+      - TEST72.25.reg
+      - TEST72.26.reg
+      - TEST72.27.reg
+      - TEST72.28.reg
+      - TEST72.29.reg
+      - TEST72.30.reg
+      - TEST72.31.reg
+      - TEST72.32.reg
+      - TEST72.33.reg
+      - TEST72.34.reg
+      - TEST72.35.reg
+      - TEST72.36.reg
+      - TEST72.37.reg
+      - TEST72.38.reg
+      - TEST72.39.reg
+      - TEST72.40.reg
+      - TEST72.41.reg
+      - TEST72.42.reg
+      - TEST72.43.reg
+      - TEST72.44.reg
+      - TEST72.45.reg
+      - TEST72.46.reg
+      - TEST72.47.reg
+      - TEST72.48.reg
+      - TEST72.49.reg
+      - TEST72.50.reg
+      - TEST72.51.reg
+      - TEST72.52.reg
+      - TEST72.53.reg
+      - TEST72.54.reg
+      - TEST72.55.reg
+      - TEST72.56.reg
+      - TEST72.57.reg
+      - TEST72.58.reg
+      - TEST72.59.reg
+      - TEST72.60.reg
+      - TEST72.61.reg
+      - TEST72.62.reg
+      - TEST72.63.reg
+      - TEST72.64.reg
+      - TEST72.65.reg
+      - TEST72.66.reg
+      - TEST72.67.reg
+      - TEST72.68.reg
+      - TEST72.69.reg
+      - TEST72.70.reg
+      - TEST72.71.reg
+  - RegisterClassName: TEST72.csrregclass
+    Registers:
+      - TEST72.0.csr
+      - TEST72.1.csr
+      - TEST72.2.csr
+      - TEST72.3.csr
+      - TEST72.4.csr
+      - TEST72.5.csr
+      - TEST72.6.csr
+      - TEST72.7.csr
+      - TEST72.8.csr
+      - TEST72.9.csr
+      - TEST72.10.csr
+      - TEST72.11.csr
+      - TEST72.12.csr
+      - TEST72.13.csr
+      - TEST72.14.csr
+      - TEST72.15.csr
+      - TEST72.16.csr
+      - TEST72.17.csr
+      - TEST72.18.csr
+      - TEST72.19.csr
+      - TEST72.20.csr
+      - TEST72.21.csr
+      - TEST72.22.csr
+      - TEST72.23.csr
+      - TEST72.24.csr
+      - TEST72.25.csr
+      - TEST72.26.csr
+      - TEST72.27.csr
+      - TEST72.28.csr
+      - TEST72.29.csr
+      - TEST72.30.csr
+      - TEST72.31.csr
+      - TEST72.32.csr
+      - TEST72.33.csr
+      - TEST72.34.csr
+      - TEST72.35.csr
+      - TEST72.36.csr
+      - TEST72.37.csr
+      - TEST72.38.csr
+      - TEST72.39.csr
+      - TEST72.40.csr
+      - TEST72.41.csr
+      - TEST72.42.csr
+      - TEST72.43.csr
+      - TEST72.44.csr
+      - TEST72.45.csr
+      - TEST72.46.csr
+      - TEST72.47.csr
+      - TEST72.48.csr
+      - TEST72.49.csr
+      - TEST72.50.csr
+      - TEST72.51.csr
+      - TEST72.52.csr
+      - TEST72.53.csr
+      - TEST72.54.csr
+      - TEST72.55.csr
+      - TEST72.56.csr
+      - TEST72.57.csr
+      - TEST72.58.csr
+      - TEST72.59.csr
+      - TEST72.60.csr
+      - TEST72.61.csr
+      - TEST72.62.csr
+      - TEST72.63.csr
+      - TEST72.64.csr
+      - TEST72.65.csr
+      - TEST72.66.csr
+      - TEST72.67.csr
+      - TEST72.68.csr
+      - TEST72.69.csr
+      - TEST72.70.csr
+      - TEST72.71.csr
+ISAs:
+  - ISAName: TEST72.isa
+InstFormats:
+  - InstFormatName: TEST72.if
+    ISA: TEST72.isa
+    FormatWidth: 32
+    Fields:
+      - FieldName: opcode
+        FieldType: CGInstCode
+        FieldWidth: 8
+        StartBit: 0
+        EndBit: 7
+        MandatoryField: true
+      - FieldName: RB
+        FieldType: CGInstReg
+        FieldWidth: 8
+        StartBit: 8
+        EndBit: 15
+        MandatoryField: false
+        RegClass: TEST72.regclass
+      - FieldName: RA
+        FieldType: CGInstReg
+        FieldWidth: 8
+        StartBit: 16
+        EndBit: 23
+        MandatoryField: false
+        RegClass: TEST72.regclass
+      - FieldName: RT
+        FieldType: CGInstReg
+        FieldWidth: 8
+        StartBit: 24
+        EndBit: 31
+        MandatoryField: false
+        RegClass: TEST72.csrregclass
+Insts:
+  - Inst: TEST72.inst0
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 1
+  - Inst: TEST72.inst1
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 2
+  - Inst: TEST72.inst2
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 3
+  - Inst: TEST72.inst3
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 4
+  - Inst: TEST72.inst4
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 5
+  - Inst: TEST72.inst5
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 6
+  - Inst: TEST72.inst6
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 7
+  - Inst: TEST72.inst7
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 8
+  - Inst: TEST72.inst8
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 9
+  - Inst: TEST72.inst9
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 10
+  - Inst: TEST72.inst10
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 11
+  - Inst: TEST72.inst11
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 12
+  - Inst: TEST72.inst12
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 13
+  - Inst: TEST72.inst13
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 14
+  - Inst: TEST72.inst14
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 15
+  - Inst: TEST72.inst15
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 16
+  - Inst: TEST72.inst16
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 17
+  - Inst: TEST72.inst17
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 18
+  - Inst: TEST72.inst18
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 19
+  - Inst: TEST72.inst19
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 20
+  - Inst: TEST72.inst20
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 21
+  - Inst: TEST72.inst21
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 22
+  - Inst: TEST72.inst22
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 23
+  - Inst: TEST72.inst23
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 24
+  - Inst: TEST72.inst24
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 25
+  - Inst: TEST72.inst25
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 26
+  - Inst: TEST72.inst26
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 27
+  - Inst: TEST72.inst27
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 28
+  - Inst: TEST72.inst28
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 29
+  - Inst: TEST72.inst29
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 30
+  - Inst: TEST72.inst30
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 31
+  - Inst: TEST72.inst31
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 32
+  - Inst: TEST72.inst32
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 33
+  - Inst: TEST72.inst33
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 34
+  - Inst: TEST72.inst34
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 35
+  - Inst: TEST72.inst35
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 36
+  - Inst: TEST72.inst36
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 37
+  - Inst: TEST72.inst37
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 38
+  - Inst: TEST72.inst38
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 39
+  - Inst: TEST72.inst39
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 40
+  - Inst: TEST72.inst40
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 41
+  - Inst: TEST72.inst41
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 42
+  - Inst: TEST72.inst42
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 43
+  - Inst: TEST72.inst43
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 44
+  - Inst: TEST72.inst44
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 45
+  - Inst: TEST72.inst45
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 46
+  - Inst: TEST72.inst46
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 47
+  - Inst: TEST72.inst47
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 48
+  - Inst: TEST72.inst48
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 49
+  - Inst: TEST72.inst49
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 50
+  - Inst: TEST72.inst50
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 51
+  - Inst: TEST72.inst51
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 52
+  - Inst: TEST72.inst52
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 53
+  - Inst: TEST72.inst53
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 54
+  - Inst: TEST72.inst54
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 55
+  - Inst: TEST72.inst55
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 56
+  - Inst: TEST72.inst56
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 57
+  - Inst: TEST72.inst57
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 58
+  - Inst: TEST72.inst58
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 59
+  - Inst: TEST72.inst59
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 60
+  - Inst: TEST72.inst60
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 61
+  - Inst: TEST72.inst61
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 62
+  - Inst: TEST72.inst62
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 63
+  - Inst: TEST72.inst63
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 64
+  - Inst: TEST72.inst64
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 65
+  - Inst: TEST72.inst65
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 66
+  - Inst: TEST72.inst66
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 67
+  - Inst: TEST72.inst67
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 68
+  - Inst: TEST72.inst68
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 69
+  - Inst: TEST72.inst69
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 70
+  - Inst: TEST72.inst70
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 71
+  - Inst: TEST72.inst71
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 72
+PseudoInsts:
+  - PseudoInst: TEST72.pinst0
+    ISA: TEST72.isa
+    Inst: TEST72.inst0
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 0
+  - PseudoInst: TEST72.pinst1
+    ISA: TEST72.isa
+    Inst: TEST72.inst1
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 1
+  - PseudoInst: TEST72.pinst2
+    ISA: TEST72.isa
+    Inst: TEST72.inst2
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 2
+  - PseudoInst: TEST72.pinst3
+    ISA: TEST72.isa
+    Inst: TEST72.inst3
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 3
+  - PseudoInst: TEST72.pinst4
+    ISA: TEST72.isa
+    Inst: TEST72.inst4
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 4
+  - PseudoInst: TEST72.pinst5
+    ISA: TEST72.isa
+    Inst: TEST72.inst5
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 5
+  - PseudoInst: TEST72.pinst6
+    ISA: TEST72.isa
+    Inst: TEST72.inst6
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 6
+  - PseudoInst: TEST72.pinst7
+    ISA: TEST72.isa
+    Inst: TEST72.inst7
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 7
+  - PseudoInst: TEST72.pinst8
+    ISA: TEST72.isa
+    Inst: TEST72.inst8
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 8
+  - PseudoInst: TEST72.pinst9
+    ISA: TEST72.isa
+    Inst: TEST72.inst9
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 9
+  - PseudoInst: TEST72.pinst10
+    ISA: TEST72.isa
+    Inst: TEST72.inst10
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 10
+  - PseudoInst: TEST72.pinst11
+    ISA: TEST72.isa
+    Inst: TEST72.inst11
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 11
+  - PseudoInst: TEST72.pinst12
+    ISA: TEST72.isa
+    Inst: TEST72.inst12
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 12
+  - PseudoInst: TEST72.pinst13
+    ISA: TEST72.isa
+    Inst: TEST72.inst13
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 13
+  - PseudoInst: TEST72.pinst14
+    ISA: TEST72.isa
+    Inst: TEST72.inst14
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 14
+  - PseudoInst: TEST72.pinst15
+    ISA: TEST72.isa
+    Inst: TEST72.inst15
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 15
+  - PseudoInst: TEST72.pinst16
+    ISA: TEST72.isa
+    Inst: TEST72.inst16
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 16
+  - PseudoInst: TEST72.pinst17
+    ISA: TEST72.isa
+    Inst: TEST72.inst17
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 17
+  - PseudoInst: TEST72.pinst18
+    ISA: TEST72.isa
+    Inst: TEST72.inst18
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 18
+  - PseudoInst: TEST72.pinst19
+    ISA: TEST72.isa
+    Inst: TEST72.inst19
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 19
+  - PseudoInst: TEST72.pinst20
+    ISA: TEST72.isa
+    Inst: TEST72.inst20
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 20
+  - PseudoInst: TEST72.pinst21
+    ISA: TEST72.isa
+    Inst: TEST72.inst21
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 21
+  - PseudoInst: TEST72.pinst22
+    ISA: TEST72.isa
+    Inst: TEST72.inst22
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 22
+  - PseudoInst: TEST72.pinst23
+    ISA: TEST72.isa
+    Inst: TEST72.inst23
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 23
+  - PseudoInst: TEST72.pinst24
+    ISA: TEST72.isa
+    Inst: TEST72.inst24
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 24
+  - PseudoInst: TEST72.pinst25
+    ISA: TEST72.isa
+    Inst: TEST72.inst25
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 25
+  - PseudoInst: TEST72.pinst26
+    ISA: TEST72.isa
+    Inst: TEST72.inst26
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 26
+  - PseudoInst: TEST72.pinst27
+    ISA: TEST72.isa
+    Inst: TEST72.inst27
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 27
+  - PseudoInst: TEST72.pinst28
+    ISA: TEST72.isa
+    Inst: TEST72.inst28
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 28
+  - PseudoInst: TEST72.pinst29
+    ISA: TEST72.isa
+    Inst: TEST72.inst29
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 29
+  - PseudoInst: TEST72.pinst30
+    ISA: TEST72.isa
+    Inst: TEST72.inst30
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 30
+  - PseudoInst: TEST72.pinst31
+    ISA: TEST72.isa
+    Inst: TEST72.inst31
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 31
+  - PseudoInst: TEST72.pinst32
+    ISA: TEST72.isa
+    Inst: TEST72.inst32
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 32
+  - PseudoInst: TEST72.pinst33
+    ISA: TEST72.isa
+    Inst: TEST72.inst33
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 33
+  - PseudoInst: TEST72.pinst34
+    ISA: TEST72.isa
+    Inst: TEST72.inst34
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 34
+  - PseudoInst: TEST72.pinst35
+    ISA: TEST72.isa
+    Inst: TEST72.inst35
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 35
+  - PseudoInst: TEST72.pinst36
+    ISA: TEST72.isa
+    Inst: TEST72.inst36
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 36
+  - PseudoInst: TEST72.pinst37
+    ISA: TEST72.isa
+    Inst: TEST72.inst37
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 37
+  - PseudoInst: TEST72.pinst38
+    ISA: TEST72.isa
+    Inst: TEST72.inst38
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 38
+  - PseudoInst: TEST72.pinst39
+    ISA: TEST72.isa
+    Inst: TEST72.inst39
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 39
+  - PseudoInst: TEST72.pinst40
+    ISA: TEST72.isa
+    Inst: TEST72.inst40
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 40
+  - PseudoInst: TEST72.pinst41
+    ISA: TEST72.isa
+    Inst: TEST72.inst41
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 41
+  - PseudoInst: TEST72.pinst42
+    ISA: TEST72.isa
+    Inst: TEST72.inst42
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 42
+  - PseudoInst: TEST72.pinst43
+    ISA: TEST72.isa
+    Inst: TEST72.inst43
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 43
+  - PseudoInst: TEST72.pinst44
+    ISA: TEST72.isa
+    Inst: TEST72.inst44
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 44
+  - PseudoInst: TEST72.pinst45
+    ISA: TEST72.isa
+    Inst: TEST72.inst45
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 45
+  - PseudoInst: TEST72.pinst46
+    ISA: TEST72.isa
+    Inst: TEST72.inst46
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 46
+  - PseudoInst: TEST72.pinst47
+    ISA: TEST72.isa
+    Inst: TEST72.inst47
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 47
+  - PseudoInst: TEST72.pinst48
+    ISA: TEST72.isa
+    Inst: TEST72.inst48
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 48
+  - PseudoInst: TEST72.pinst49
+    ISA: TEST72.isa
+    Inst: TEST72.inst49
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 49
+  - PseudoInst: TEST72.pinst50
+    ISA: TEST72.isa
+    Inst: TEST72.inst50
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 50
+  - PseudoInst: TEST72.pinst51
+    ISA: TEST72.isa
+    Inst: TEST72.inst51
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 51
+  - PseudoInst: TEST72.pinst52
+    ISA: TEST72.isa
+    Inst: TEST72.inst52
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 52
+  - PseudoInst: TEST72.pinst53
+    ISA: TEST72.isa
+    Inst: TEST72.inst53
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 53
+  - PseudoInst: TEST72.pinst54
+    ISA: TEST72.isa
+    Inst: TEST72.inst54
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 54
+  - PseudoInst: TEST72.pinst55
+    ISA: TEST72.isa
+    Inst: TEST72.inst55
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 55
+  - PseudoInst: TEST72.pinst56
+    ISA: TEST72.isa
+    Inst: TEST72.inst56
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 56
+  - PseudoInst: TEST72.pinst57
+    ISA: TEST72.isa
+    Inst: TEST72.inst57
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 57
+  - PseudoInst: TEST72.pinst58
+    ISA: TEST72.isa
+    Inst: TEST72.inst58
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 58
+  - PseudoInst: TEST72.pinst59
+    ISA: TEST72.isa
+    Inst: TEST72.inst59
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 59
+  - PseudoInst: TEST72.pinst60
+    ISA: TEST72.isa
+    Inst: TEST72.inst60
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 60
+  - PseudoInst: TEST72.pinst61
+    ISA: TEST72.isa
+    Inst: TEST72.inst61
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 61
+  - PseudoInst: TEST72.pinst62
+    ISA: TEST72.isa
+    Inst: TEST72.inst62
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 62
+  - PseudoInst: TEST72.pinst63
+    ISA: TEST72.isa
+    Inst: TEST72.inst63
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 63
+  - PseudoInst: TEST72.pinst64
+    ISA: TEST72.isa
+    Inst: TEST72.inst64
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 64
+  - PseudoInst: TEST72.pinst65
+    ISA: TEST72.isa
+    Inst: TEST72.inst65
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 65
+  - PseudoInst: TEST72.pinst66
+    ISA: TEST72.isa
+    Inst: TEST72.inst66
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 66
+  - PseudoInst: TEST72.pinst67
+    ISA: TEST72.isa
+    Inst: TEST72.inst67
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 67
+  - PseudoInst: TEST72.pinst68
+    ISA: TEST72.isa
+    Inst: TEST72.inst68
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 68
+  - PseudoInst: TEST72.pinst69
+    ISA: TEST72.isa
+    Inst: TEST72.inst69
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 69
+  - PseudoInst: TEST72.pinst70
+    ISA: TEST72.isa
+    Inst: TEST72.inst70
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 70
+  - PseudoInst: TEST72.pinst71
+    ISA: TEST72.isa
+    Inst: TEST72.inst71
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 71
+Caches:
+  - Cache: TEST72.L2.cache
+    Sets: 2
+    Ways: 8
+  - Cache: TEST72.core0.L1.cache
+    Sets: 1
+    Ways: 1
+    SubLevel: TEST72.L2.cache
+  - Cache: TEST72.L2.cache
+    Sets: 2
+    Ways: 8
+  - Cache: TEST72.core1.L1.cache
+    Sets: 1
+    Ways: 1
+    SubLevel: TEST72.L2.cache
+  - Cache: TEST72.L2.cache
+    Sets: 2
+    Ways: 8
+  - Cache: TEST72.core2.L1.cache
+    Sets: 1
+    Ways: 1
+    SubLevel: TEST72.L2.cache
+  - Cache: TEST72.L2.cache
+    Sets: 2
+    Ways: 8
+  - Cache: TEST72.core3.L1.cache
+    Sets: 1
+    Ways: 1
+    SubLevel: TEST72.L2.cache
+  - Cache: TEST72.L2.cache
+    Sets: 2
+    Ways: 8
+Comms:
+  - Comm: TEST72.comm
+    Type: NOC
+    Width: 64
+    Endpoints:
+      - TEST72.core0
+      - TEST72.core1
+      - TEST72.core2
+      - TEST72.core3
+      - TEST72.L2.cache
+      - TEST72.vtp
+      - TEST72.0.mctrl
+      - TEST72.1.mctrl
+      - TEST72.2.mctrl
+      - TEST72.3.mctrl
+Scratchpads:
+  - Scratchpad: TEST72.0.spad
+    MemSize: 1024
+    RqstPorts: 1
+    RspPorts: 1
+    StartAddr: 34359739392
+  - Scratchpad: TEST72.1.spad
+    MemSize: 2048
+    RqstPorts: 1
+    RspPorts: 1
+    StartAddr: 34359740416
+  - Scratchpad: TEST72.2.spad
+    MemSize: 3072
+    RqstPorts: 1
+    RspPorts: 1
+    StartAddr: 34359741440
+  - Scratchpad: TEST72.3.spad
+    MemSize: 4096
+    RqstPorts: 1
+    RspPorts: 1
+    StartAddr: 34359742464
+MemoryControllers:
+  - MemoryController: TEST72.0.mctrl
+    Ports: 2
+  - MemoryController: TEST72.1.mctrl
+    Ports: 2
+  - MemoryController: TEST72.2.mctrl
+    Ports: 2
+  - MemoryController: TEST72.3.mctrl
+    Ports: 2
+VTPControllers:
+  - VTP: TEST72.vtp
+Extensions:
+  - Extension: TEST72.ext0
+    Type: unknown
+    Registers:
+      - RegName: TEST72.ext0.reg
+        Width: 64
+        Index: 0
+        IsFixedValue: false
+        IsSIMD: false
+        RWReg: false
+        ROReg: false
+        CSRReg: true
+        AMSReg: false
+        TUSReg: false
+        Shared: false
+    RegClasses:
+      - RegisterClassName: TEST72.ext0.regclass
+        Registers:
+          - TEST72.ext0.reg
+    ISAs:
+      - ISAName: TEST72.ext0.isa
+    RTLFile: TEST72.ext0.v
+  - Extension: TEST72.ext1
+    Type: unknown
+    Registers:
+      - RegName: TEST72.ext1.reg
+        Width: 64
+        Index: 0
+        IsFixedValue: false
+        IsSIMD: false
+        RWReg: false
+        ROReg: false
+        CSRReg: true
+        AMSReg: false
+        TUSReg: false
+        Shared: false
+    RegClasses:
+      - RegisterClassName: TEST72.ext1.regclass
+        Registers:
+          - TEST72.ext1.reg
+    ISAs:
+      - ISAName: TEST72.ext1.isa
+    RTLFile: TEST72.ext1.v
+  - Extension: TEST72.ext2
+    Type: unknown
+    Registers:
+      - RegName: TEST72.ext2.reg
+        Width: 64
+        Index: 0
+        IsFixedValue: false
+        IsSIMD: false
+        RWReg: false
+        ROReg: false
+        CSRReg: true
+        AMSReg: false
+        TUSReg: false
+        Shared: false
+    RegClasses:
+      - RegisterClassName: TEST72.ext2.regclass
+        Registers:
+          - TEST72.ext2.reg
+    ISAs:
+      - ISAName: TEST72.ext2.isa
+    RTLFile: TEST72.ext2.v
+  - Extension: TEST72.ext3
+    Type: unknown
+    Registers:
+      - RegName: TEST72.ext3.reg
+        Width: 64
+        Index: 0
+        IsFixedValue: false
+        IsSIMD: false
+        RWReg: false
+        ROReg: false
+        CSRReg: true
+        AMSReg: false
+        TUSReg: false
+        Shared: false
+    RegClasses:
+      - RegisterClassName: TEST72.ext3.regclass
+        Registers:
+          - TEST72.ext3.reg
+    ISAs:
+      - ISAName: TEST72.ext3.isa
+    RTLFile: TEST72.ext3.v
+Cores:
+  - Core: TEST72.core0
+    ThreadUnits: 1
+    Cache: TEST72.core0.L1.cache
+    ISA: TEST72.isa
+    RegisterClasses:
+      - RegClass: TEST72.regclass
+      - RegClass: TEST72.csrregclass
+    Extensions:
+      - Extension: TEST72.ext0
+  - Core: TEST72.core1
+    ThreadUnits: 2
+    Cache: TEST72.core1.L1.cache
+    ISA: TEST72.isa
+    RegisterClasses:
+      - RegClass: TEST72.regclass
+      - RegClass: TEST72.csrregclass
+    Extensions:
+      - Extension: TEST72.ext1
+  - Core: TEST72.core2
+    ThreadUnits: 3
+    Cache: TEST72.core2.L1.cache
+    ISA: TEST72.isa
+    RegisterClasses:
+      - RegClass: TEST72.regclass
+      - RegClass: TEST72.csrregclass
+    Extensions:
+      - Extension: TEST72.ext2
+  - Core: TEST72.core3
+    ThreadUnits: 4
+    Cache: TEST72.core3.L1.cache
+    ISA: TEST72.isa
+    RegisterClasses:
+      - RegClass: TEST72.regclass
+      - RegClass: TEST72.csrregclass
+    Extensions:
+      - Extension: TEST72.ext3
+Socs:
+  - Soc: TEST72.soc
+    Cores:
+      - Core: TEST72.core0
+      - Core: TEST72.core1
+      - Core: TEST72.core2
+      - Core: TEST72.core3

--- a/test/Yaml/Reader/MissingData/TEST37.yaml
+++ b/test/Yaml/Reader/MissingData/TEST37.yaml
@@ -1,0 +1,3143 @@
+ProjectInfo:
+  - ProjectName: TEST72
+    ProjectRoot: ./
+    ProjectType: unknown
+    ChiselMajorVersion: 3
+    ChiselMinorVersion: 0
+Registers:
+  - RegName: TEST72.0.reg
+    Width: 64
+    Index: 0
+    PseudoName: pseudoreg.0
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+    SubRegs:
+      - SubReg: SUBREG0
+        StartBit:
+        EndBit: 31
+      - SubReg: SUBREG1
+        StartBit: 32
+        EndBit: 63
+  - RegName: TEST72.1.reg
+    Width: 64
+    Index: 1
+    PseudoName: pseudoreg.1
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.2.reg
+    Width: 64
+    Index: 2
+    PseudoName: pseudoreg.2
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.3.reg
+    Width: 64
+    Index: 3
+    PseudoName: pseudoreg.3
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.4.reg
+    Width: 64
+    Index: 4
+    PseudoName: pseudoreg.4
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.5.reg
+    Width: 64
+    Index: 5
+    PseudoName: pseudoreg.5
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.6.reg
+    Width: 64
+    Index: 6
+    PseudoName: pseudoreg.6
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.7.reg
+    Width: 64
+    Index: 7
+    PseudoName: pseudoreg.7
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.8.reg
+    Width: 64
+    Index: 8
+    PseudoName: pseudoreg.8
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.9.reg
+    Width: 64
+    Index: 9
+    PseudoName: pseudoreg.9
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.10.reg
+    Width: 64
+    Index: 10
+    PseudoName: pseudoreg.10
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.11.reg
+    Width: 64
+    Index: 11
+    PseudoName: pseudoreg.11
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.12.reg
+    Width: 64
+    Index: 12
+    PseudoName: pseudoreg.12
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.13.reg
+    Width: 64
+    Index: 13
+    PseudoName: pseudoreg.13
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.14.reg
+    Width: 64
+    Index: 14
+    PseudoName: pseudoreg.14
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.15.reg
+    Width: 64
+    Index: 15
+    PseudoName: pseudoreg.15
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.16.reg
+    Width: 64
+    Index: 16
+    PseudoName: pseudoreg.16
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.17.reg
+    Width: 64
+    Index: 17
+    PseudoName: pseudoreg.17
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.18.reg
+    Width: 64
+    Index: 18
+    PseudoName: pseudoreg.18
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.19.reg
+    Width: 64
+    Index: 19
+    PseudoName: pseudoreg.19
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.20.reg
+    Width: 64
+    Index: 20
+    PseudoName: pseudoreg.20
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.21.reg
+    Width: 64
+    Index: 21
+    PseudoName: pseudoreg.21
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.22.reg
+    Width: 64
+    Index: 22
+    PseudoName: pseudoreg.22
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.23.reg
+    Width: 64
+    Index: 23
+    PseudoName: pseudoreg.23
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.24.reg
+    Width: 64
+    Index: 24
+    PseudoName: pseudoreg.24
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.25.reg
+    Width: 64
+    Index: 25
+    PseudoName: pseudoreg.25
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.26.reg
+    Width: 64
+    Index: 26
+    PseudoName: pseudoreg.26
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.27.reg
+    Width: 64
+    Index: 27
+    PseudoName: pseudoreg.27
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.28.reg
+    Width: 64
+    Index: 28
+    PseudoName: pseudoreg.28
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.29.reg
+    Width: 64
+    Index: 29
+    PseudoName: pseudoreg.29
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.30.reg
+    Width: 64
+    Index: 30
+    PseudoName: pseudoreg.30
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.31.reg
+    Width: 64
+    Index: 31
+    PseudoName: pseudoreg.31
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.32.reg
+    Width: 64
+    Index: 32
+    PseudoName: pseudoreg.32
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.33.reg
+    Width: 64
+    Index: 33
+    PseudoName: pseudoreg.33
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.34.reg
+    Width: 64
+    Index: 34
+    PseudoName: pseudoreg.34
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.35.reg
+    Width: 64
+    Index: 35
+    PseudoName: pseudoreg.35
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.36.reg
+    Width: 64
+    Index: 36
+    PseudoName: pseudoreg.36
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.37.reg
+    Width: 64
+    Index: 37
+    PseudoName: pseudoreg.37
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.38.reg
+    Width: 64
+    Index: 38
+    PseudoName: pseudoreg.38
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.39.reg
+    Width: 64
+    Index: 39
+    PseudoName: pseudoreg.39
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.40.reg
+    Width: 64
+    Index: 40
+    PseudoName: pseudoreg.40
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.41.reg
+    Width: 64
+    Index: 41
+    PseudoName: pseudoreg.41
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.42.reg
+    Width: 64
+    Index: 42
+    PseudoName: pseudoreg.42
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.43.reg
+    Width: 64
+    Index: 43
+    PseudoName: pseudoreg.43
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.44.reg
+    Width: 64
+    Index: 44
+    PseudoName: pseudoreg.44
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.45.reg
+    Width: 64
+    Index: 45
+    PseudoName: pseudoreg.45
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.46.reg
+    Width: 64
+    Index: 46
+    PseudoName: pseudoreg.46
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.47.reg
+    Width: 64
+    Index: 47
+    PseudoName: pseudoreg.47
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.48.reg
+    Width: 64
+    Index: 48
+    PseudoName: pseudoreg.48
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.49.reg
+    Width: 64
+    Index: 49
+    PseudoName: pseudoreg.49
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.50.reg
+    Width: 64
+    Index: 50
+    PseudoName: pseudoreg.50
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.51.reg
+    Width: 64
+    Index: 51
+    PseudoName: pseudoreg.51
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.52.reg
+    Width: 64
+    Index: 52
+    PseudoName: pseudoreg.52
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.53.reg
+    Width: 64
+    Index: 53
+    PseudoName: pseudoreg.53
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.54.reg
+    Width: 64
+    Index: 54
+    PseudoName: pseudoreg.54
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.55.reg
+    Width: 64
+    Index: 55
+    PseudoName: pseudoreg.55
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.56.reg
+    Width: 64
+    Index: 56
+    PseudoName: pseudoreg.56
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.57.reg
+    Width: 64
+    Index: 57
+    PseudoName: pseudoreg.57
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.58.reg
+    Width: 64
+    Index: 58
+    PseudoName: pseudoreg.58
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.59.reg
+    Width: 64
+    Index: 59
+    PseudoName: pseudoreg.59
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.60.reg
+    Width: 64
+    Index: 60
+    PseudoName: pseudoreg.60
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.61.reg
+    Width: 64
+    Index: 61
+    PseudoName: pseudoreg.61
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.62.reg
+    Width: 64
+    Index: 62
+    PseudoName: pseudoreg.62
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.63.reg
+    Width: 64
+    Index: 63
+    PseudoName: pseudoreg.63
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.64.reg
+    Width: 64
+    Index: 64
+    PseudoName: pseudoreg.64
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.65.reg
+    Width: 64
+    Index: 65
+    PseudoName: pseudoreg.65
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.66.reg
+    Width: 64
+    Index: 66
+    PseudoName: pseudoreg.66
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.67.reg
+    Width: 64
+    Index: 67
+    PseudoName: pseudoreg.67
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.68.reg
+    Width: 64
+    Index: 68
+    PseudoName: pseudoreg.68
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.69.reg
+    Width: 64
+    Index: 69
+    PseudoName: pseudoreg.69
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.70.reg
+    Width: 64
+    Index: 70
+    PseudoName: pseudoreg.70
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.71.reg
+    Width: 64
+    Index: 71
+    PseudoName: pseudoreg.71
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.0.csr
+    Width: 64
+    Index: 0
+    PseudoName: csr.0
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.1.csr
+    Width: 64
+    Index: 1
+    PseudoName: csr.1
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.2.csr
+    Width: 64
+    Index: 2
+    PseudoName: csr.2
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.3.csr
+    Width: 64
+    Index: 3
+    PseudoName: csr.3
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.4.csr
+    Width: 64
+    Index: 4
+    PseudoName: csr.4
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.5.csr
+    Width: 64
+    Index: 5
+    PseudoName: csr.5
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.6.csr
+    Width: 64
+    Index: 6
+    PseudoName: csr.6
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.7.csr
+    Width: 64
+    Index: 7
+    PseudoName: csr.7
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.8.csr
+    Width: 64
+    Index: 8
+    PseudoName: csr.8
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.9.csr
+    Width: 64
+    Index: 9
+    PseudoName: csr.9
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.10.csr
+    Width: 64
+    Index: 10
+    PseudoName: csr.10
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.11.csr
+    Width: 64
+    Index: 11
+    PseudoName: csr.11
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.12.csr
+    Width: 64
+    Index: 12
+    PseudoName: csr.12
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.13.csr
+    Width: 64
+    Index: 13
+    PseudoName: csr.13
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.14.csr
+    Width: 64
+    Index: 14
+    PseudoName: csr.14
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.15.csr
+    Width: 64
+    Index: 15
+    PseudoName: csr.15
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.16.csr
+    Width: 64
+    Index: 16
+    PseudoName: csr.16
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.17.csr
+    Width: 64
+    Index: 17
+    PseudoName: csr.17
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.18.csr
+    Width: 64
+    Index: 18
+    PseudoName: csr.18
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.19.csr
+    Width: 64
+    Index: 19
+    PseudoName: csr.19
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.20.csr
+    Width: 64
+    Index: 20
+    PseudoName: csr.20
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.21.csr
+    Width: 64
+    Index: 21
+    PseudoName: csr.21
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.22.csr
+    Width: 64
+    Index: 22
+    PseudoName: csr.22
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.23.csr
+    Width: 64
+    Index: 23
+    PseudoName: csr.23
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.24.csr
+    Width: 64
+    Index: 24
+    PseudoName: csr.24
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.25.csr
+    Width: 64
+    Index: 25
+    PseudoName: csr.25
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.26.csr
+    Width: 64
+    Index: 26
+    PseudoName: csr.26
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.27.csr
+    Width: 64
+    Index: 27
+    PseudoName: csr.27
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.28.csr
+    Width: 64
+    Index: 28
+    PseudoName: csr.28
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.29.csr
+    Width: 64
+    Index: 29
+    PseudoName: csr.29
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.30.csr
+    Width: 64
+    Index: 30
+    PseudoName: csr.30
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.31.csr
+    Width: 64
+    Index: 31
+    PseudoName: csr.31
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.32.csr
+    Width: 64
+    Index: 32
+    PseudoName: csr.32
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.33.csr
+    Width: 64
+    Index: 33
+    PseudoName: csr.33
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.34.csr
+    Width: 64
+    Index: 34
+    PseudoName: csr.34
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.35.csr
+    Width: 64
+    Index: 35
+    PseudoName: csr.35
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.36.csr
+    Width: 64
+    Index: 36
+    PseudoName: csr.36
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.37.csr
+    Width: 64
+    Index: 37
+    PseudoName: csr.37
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.38.csr
+    Width: 64
+    Index: 38
+    PseudoName: csr.38
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.39.csr
+    Width: 64
+    Index: 39
+    PseudoName: csr.39
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.40.csr
+    Width: 64
+    Index: 40
+    PseudoName: csr.40
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.41.csr
+    Width: 64
+    Index: 41
+    PseudoName: csr.41
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.42.csr
+    Width: 64
+    Index: 42
+    PseudoName: csr.42
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.43.csr
+    Width: 64
+    Index: 43
+    PseudoName: csr.43
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.44.csr
+    Width: 64
+    Index: 44
+    PseudoName: csr.44
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.45.csr
+    Width: 64
+    Index: 45
+    PseudoName: csr.45
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.46.csr
+    Width: 64
+    Index: 46
+    PseudoName: csr.46
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.47.csr
+    Width: 64
+    Index: 47
+    PseudoName: csr.47
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.48.csr
+    Width: 64
+    Index: 48
+    PseudoName: csr.48
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.49.csr
+    Width: 64
+    Index: 49
+    PseudoName: csr.49
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.50.csr
+    Width: 64
+    Index: 50
+    PseudoName: csr.50
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.51.csr
+    Width: 64
+    Index: 51
+    PseudoName: csr.51
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.52.csr
+    Width: 64
+    Index: 52
+    PseudoName: csr.52
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.53.csr
+    Width: 64
+    Index: 53
+    PseudoName: csr.53
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.54.csr
+    Width: 64
+    Index: 54
+    PseudoName: csr.54
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.55.csr
+    Width: 64
+    Index: 55
+    PseudoName: csr.55
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.56.csr
+    Width: 64
+    Index: 56
+    PseudoName: csr.56
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.57.csr
+    Width: 64
+    Index: 57
+    PseudoName: csr.57
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.58.csr
+    Width: 64
+    Index: 58
+    PseudoName: csr.58
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.59.csr
+    Width: 64
+    Index: 59
+    PseudoName: csr.59
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.60.csr
+    Width: 64
+    Index: 60
+    PseudoName: csr.60
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.61.csr
+    Width: 64
+    Index: 61
+    PseudoName: csr.61
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.62.csr
+    Width: 64
+    Index: 62
+    PseudoName: csr.62
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.63.csr
+    Width: 64
+    Index: 63
+    PseudoName: csr.63
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.64.csr
+    Width: 64
+    Index: 64
+    PseudoName: csr.64
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.65.csr
+    Width: 64
+    Index: 65
+    PseudoName: csr.65
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.66.csr
+    Width: 64
+    Index: 66
+    PseudoName: csr.66
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.67.csr
+    Width: 64
+    Index: 67
+    PseudoName: csr.67
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.68.csr
+    Width: 64
+    Index: 68
+    PseudoName: csr.68
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.69.csr
+    Width: 64
+    Index: 69
+    PseudoName: csr.69
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.70.csr
+    Width: 64
+    Index: 70
+    PseudoName: csr.70
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.71.csr
+    Width: 64
+    Index: 71
+    PseudoName: csr.71
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+RegClasses:
+  - RegisterClassName: TEST72.regclass
+    Registers:
+      - TEST72.0.reg
+      - TEST72.1.reg
+      - TEST72.2.reg
+      - TEST72.3.reg
+      - TEST72.4.reg
+      - TEST72.5.reg
+      - TEST72.6.reg
+      - TEST72.7.reg
+      - TEST72.8.reg
+      - TEST72.9.reg
+      - TEST72.10.reg
+      - TEST72.11.reg
+      - TEST72.12.reg
+      - TEST72.13.reg
+      - TEST72.14.reg
+      - TEST72.15.reg
+      - TEST72.16.reg
+      - TEST72.17.reg
+      - TEST72.18.reg
+      - TEST72.19.reg
+      - TEST72.20.reg
+      - TEST72.21.reg
+      - TEST72.22.reg
+      - TEST72.23.reg
+      - TEST72.24.reg
+      - TEST72.25.reg
+      - TEST72.26.reg
+      - TEST72.27.reg
+      - TEST72.28.reg
+      - TEST72.29.reg
+      - TEST72.30.reg
+      - TEST72.31.reg
+      - TEST72.32.reg
+      - TEST72.33.reg
+      - TEST72.34.reg
+      - TEST72.35.reg
+      - TEST72.36.reg
+      - TEST72.37.reg
+      - TEST72.38.reg
+      - TEST72.39.reg
+      - TEST72.40.reg
+      - TEST72.41.reg
+      - TEST72.42.reg
+      - TEST72.43.reg
+      - TEST72.44.reg
+      - TEST72.45.reg
+      - TEST72.46.reg
+      - TEST72.47.reg
+      - TEST72.48.reg
+      - TEST72.49.reg
+      - TEST72.50.reg
+      - TEST72.51.reg
+      - TEST72.52.reg
+      - TEST72.53.reg
+      - TEST72.54.reg
+      - TEST72.55.reg
+      - TEST72.56.reg
+      - TEST72.57.reg
+      - TEST72.58.reg
+      - TEST72.59.reg
+      - TEST72.60.reg
+      - TEST72.61.reg
+      - TEST72.62.reg
+      - TEST72.63.reg
+      - TEST72.64.reg
+      - TEST72.65.reg
+      - TEST72.66.reg
+      - TEST72.67.reg
+      - TEST72.68.reg
+      - TEST72.69.reg
+      - TEST72.70.reg
+      - TEST72.71.reg
+  - RegisterClassName: TEST72.csrregclass
+    Registers:
+      - TEST72.0.csr
+      - TEST72.1.csr
+      - TEST72.2.csr
+      - TEST72.3.csr
+      - TEST72.4.csr
+      - TEST72.5.csr
+      - TEST72.6.csr
+      - TEST72.7.csr
+      - TEST72.8.csr
+      - TEST72.9.csr
+      - TEST72.10.csr
+      - TEST72.11.csr
+      - TEST72.12.csr
+      - TEST72.13.csr
+      - TEST72.14.csr
+      - TEST72.15.csr
+      - TEST72.16.csr
+      - TEST72.17.csr
+      - TEST72.18.csr
+      - TEST72.19.csr
+      - TEST72.20.csr
+      - TEST72.21.csr
+      - TEST72.22.csr
+      - TEST72.23.csr
+      - TEST72.24.csr
+      - TEST72.25.csr
+      - TEST72.26.csr
+      - TEST72.27.csr
+      - TEST72.28.csr
+      - TEST72.29.csr
+      - TEST72.30.csr
+      - TEST72.31.csr
+      - TEST72.32.csr
+      - TEST72.33.csr
+      - TEST72.34.csr
+      - TEST72.35.csr
+      - TEST72.36.csr
+      - TEST72.37.csr
+      - TEST72.38.csr
+      - TEST72.39.csr
+      - TEST72.40.csr
+      - TEST72.41.csr
+      - TEST72.42.csr
+      - TEST72.43.csr
+      - TEST72.44.csr
+      - TEST72.45.csr
+      - TEST72.46.csr
+      - TEST72.47.csr
+      - TEST72.48.csr
+      - TEST72.49.csr
+      - TEST72.50.csr
+      - TEST72.51.csr
+      - TEST72.52.csr
+      - TEST72.53.csr
+      - TEST72.54.csr
+      - TEST72.55.csr
+      - TEST72.56.csr
+      - TEST72.57.csr
+      - TEST72.58.csr
+      - TEST72.59.csr
+      - TEST72.60.csr
+      - TEST72.61.csr
+      - TEST72.62.csr
+      - TEST72.63.csr
+      - TEST72.64.csr
+      - TEST72.65.csr
+      - TEST72.66.csr
+      - TEST72.67.csr
+      - TEST72.68.csr
+      - TEST72.69.csr
+      - TEST72.70.csr
+      - TEST72.71.csr
+ISAs:
+  - ISAName: TEST72.isa
+InstFormats:
+  - InstFormatName: TEST72.if
+    ISA: TEST72.isa
+    FormatWidth: 32
+    Fields:
+      - FieldName: opcode
+        FieldType: CGInstCode
+        FieldWidth: 8
+        StartBit: 0
+        EndBit: 7
+        MandatoryField: true
+      - FieldName: RB
+        FieldType: CGInstReg
+        FieldWidth: 8
+        StartBit: 8
+        EndBit: 15
+        MandatoryField: false
+        RegClass: TEST72.regclass
+      - FieldName: RA
+        FieldType: CGInstReg
+        FieldWidth: 8
+        StartBit: 16
+        EndBit: 23
+        MandatoryField: false
+        RegClass: TEST72.regclass
+      - FieldName: RT
+        FieldType: CGInstReg
+        FieldWidth: 8
+        StartBit: 24
+        EndBit: 31
+        MandatoryField: false
+        RegClass: TEST72.csrregclass
+Insts:
+  - Inst: TEST72.inst0
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 1
+  - Inst: TEST72.inst1
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 2
+  - Inst: TEST72.inst2
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 3
+  - Inst: TEST72.inst3
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 4
+  - Inst: TEST72.inst4
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 5
+  - Inst: TEST72.inst5
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 6
+  - Inst: TEST72.inst6
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 7
+  - Inst: TEST72.inst7
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 8
+  - Inst: TEST72.inst8
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 9
+  - Inst: TEST72.inst9
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 10
+  - Inst: TEST72.inst10
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 11
+  - Inst: TEST72.inst11
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 12
+  - Inst: TEST72.inst12
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 13
+  - Inst: TEST72.inst13
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 14
+  - Inst: TEST72.inst14
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 15
+  - Inst: TEST72.inst15
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 16
+  - Inst: TEST72.inst16
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 17
+  - Inst: TEST72.inst17
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 18
+  - Inst: TEST72.inst18
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 19
+  - Inst: TEST72.inst19
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 20
+  - Inst: TEST72.inst20
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 21
+  - Inst: TEST72.inst21
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 22
+  - Inst: TEST72.inst22
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 23
+  - Inst: TEST72.inst23
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 24
+  - Inst: TEST72.inst24
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 25
+  - Inst: TEST72.inst25
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 26
+  - Inst: TEST72.inst26
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 27
+  - Inst: TEST72.inst27
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 28
+  - Inst: TEST72.inst28
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 29
+  - Inst: TEST72.inst29
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 30
+  - Inst: TEST72.inst30
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 31
+  - Inst: TEST72.inst31
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 32
+  - Inst: TEST72.inst32
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 33
+  - Inst: TEST72.inst33
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 34
+  - Inst: TEST72.inst34
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 35
+  - Inst: TEST72.inst35
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 36
+  - Inst: TEST72.inst36
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 37
+  - Inst: TEST72.inst37
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 38
+  - Inst: TEST72.inst38
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 39
+  - Inst: TEST72.inst39
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 40
+  - Inst: TEST72.inst40
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 41
+  - Inst: TEST72.inst41
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 42
+  - Inst: TEST72.inst42
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 43
+  - Inst: TEST72.inst43
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 44
+  - Inst: TEST72.inst44
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 45
+  - Inst: TEST72.inst45
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 46
+  - Inst: TEST72.inst46
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 47
+  - Inst: TEST72.inst47
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 48
+  - Inst: TEST72.inst48
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 49
+  - Inst: TEST72.inst49
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 50
+  - Inst: TEST72.inst50
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 51
+  - Inst: TEST72.inst51
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 52
+  - Inst: TEST72.inst52
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 53
+  - Inst: TEST72.inst53
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 54
+  - Inst: TEST72.inst54
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 55
+  - Inst: TEST72.inst55
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 56
+  - Inst: TEST72.inst56
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 57
+  - Inst: TEST72.inst57
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 58
+  - Inst: TEST72.inst58
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 59
+  - Inst: TEST72.inst59
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 60
+  - Inst: TEST72.inst60
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 61
+  - Inst: TEST72.inst61
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 62
+  - Inst: TEST72.inst62
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 63
+  - Inst: TEST72.inst63
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 64
+  - Inst: TEST72.inst64
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 65
+  - Inst: TEST72.inst65
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 66
+  - Inst: TEST72.inst66
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 67
+  - Inst: TEST72.inst67
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 68
+  - Inst: TEST72.inst68
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 69
+  - Inst: TEST72.inst69
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 70
+  - Inst: TEST72.inst70
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 71
+  - Inst: TEST72.inst71
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 72
+PseudoInsts:
+  - PseudoInst: TEST72.pinst0
+    ISA: TEST72.isa
+    Inst: TEST72.inst0
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 0
+  - PseudoInst: TEST72.pinst1
+    ISA: TEST72.isa
+    Inst: TEST72.inst1
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 1
+  - PseudoInst: TEST72.pinst2
+    ISA: TEST72.isa
+    Inst: TEST72.inst2
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 2
+  - PseudoInst: TEST72.pinst3
+    ISA: TEST72.isa
+    Inst: TEST72.inst3
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 3
+  - PseudoInst: TEST72.pinst4
+    ISA: TEST72.isa
+    Inst: TEST72.inst4
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 4
+  - PseudoInst: TEST72.pinst5
+    ISA: TEST72.isa
+    Inst: TEST72.inst5
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 5
+  - PseudoInst: TEST72.pinst6
+    ISA: TEST72.isa
+    Inst: TEST72.inst6
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 6
+  - PseudoInst: TEST72.pinst7
+    ISA: TEST72.isa
+    Inst: TEST72.inst7
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 7
+  - PseudoInst: TEST72.pinst8
+    ISA: TEST72.isa
+    Inst: TEST72.inst8
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 8
+  - PseudoInst: TEST72.pinst9
+    ISA: TEST72.isa
+    Inst: TEST72.inst9
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 9
+  - PseudoInst: TEST72.pinst10
+    ISA: TEST72.isa
+    Inst: TEST72.inst10
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 10
+  - PseudoInst: TEST72.pinst11
+    ISA: TEST72.isa
+    Inst: TEST72.inst11
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 11
+  - PseudoInst: TEST72.pinst12
+    ISA: TEST72.isa
+    Inst: TEST72.inst12
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 12
+  - PseudoInst: TEST72.pinst13
+    ISA: TEST72.isa
+    Inst: TEST72.inst13
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 13
+  - PseudoInst: TEST72.pinst14
+    ISA: TEST72.isa
+    Inst: TEST72.inst14
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 14
+  - PseudoInst: TEST72.pinst15
+    ISA: TEST72.isa
+    Inst: TEST72.inst15
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 15
+  - PseudoInst: TEST72.pinst16
+    ISA: TEST72.isa
+    Inst: TEST72.inst16
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 16
+  - PseudoInst: TEST72.pinst17
+    ISA: TEST72.isa
+    Inst: TEST72.inst17
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 17
+  - PseudoInst: TEST72.pinst18
+    ISA: TEST72.isa
+    Inst: TEST72.inst18
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 18
+  - PseudoInst: TEST72.pinst19
+    ISA: TEST72.isa
+    Inst: TEST72.inst19
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 19
+  - PseudoInst: TEST72.pinst20
+    ISA: TEST72.isa
+    Inst: TEST72.inst20
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 20
+  - PseudoInst: TEST72.pinst21
+    ISA: TEST72.isa
+    Inst: TEST72.inst21
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 21
+  - PseudoInst: TEST72.pinst22
+    ISA: TEST72.isa
+    Inst: TEST72.inst22
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 22
+  - PseudoInst: TEST72.pinst23
+    ISA: TEST72.isa
+    Inst: TEST72.inst23
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 23
+  - PseudoInst: TEST72.pinst24
+    ISA: TEST72.isa
+    Inst: TEST72.inst24
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 24
+  - PseudoInst: TEST72.pinst25
+    ISA: TEST72.isa
+    Inst: TEST72.inst25
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 25
+  - PseudoInst: TEST72.pinst26
+    ISA: TEST72.isa
+    Inst: TEST72.inst26
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 26
+  - PseudoInst: TEST72.pinst27
+    ISA: TEST72.isa
+    Inst: TEST72.inst27
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 27
+  - PseudoInst: TEST72.pinst28
+    ISA: TEST72.isa
+    Inst: TEST72.inst28
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 28
+  - PseudoInst: TEST72.pinst29
+    ISA: TEST72.isa
+    Inst: TEST72.inst29
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 29
+  - PseudoInst: TEST72.pinst30
+    ISA: TEST72.isa
+    Inst: TEST72.inst30
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 30
+  - PseudoInst: TEST72.pinst31
+    ISA: TEST72.isa
+    Inst: TEST72.inst31
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 31
+  - PseudoInst: TEST72.pinst32
+    ISA: TEST72.isa
+    Inst: TEST72.inst32
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 32
+  - PseudoInst: TEST72.pinst33
+    ISA: TEST72.isa
+    Inst: TEST72.inst33
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 33
+  - PseudoInst: TEST72.pinst34
+    ISA: TEST72.isa
+    Inst: TEST72.inst34
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 34
+  - PseudoInst: TEST72.pinst35
+    ISA: TEST72.isa
+    Inst: TEST72.inst35
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 35
+  - PseudoInst: TEST72.pinst36
+    ISA: TEST72.isa
+    Inst: TEST72.inst36
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 36
+  - PseudoInst: TEST72.pinst37
+    ISA: TEST72.isa
+    Inst: TEST72.inst37
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 37
+  - PseudoInst: TEST72.pinst38
+    ISA: TEST72.isa
+    Inst: TEST72.inst38
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 38
+  - PseudoInst: TEST72.pinst39
+    ISA: TEST72.isa
+    Inst: TEST72.inst39
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 39
+  - PseudoInst: TEST72.pinst40
+    ISA: TEST72.isa
+    Inst: TEST72.inst40
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 40
+  - PseudoInst: TEST72.pinst41
+    ISA: TEST72.isa
+    Inst: TEST72.inst41
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 41
+  - PseudoInst: TEST72.pinst42
+    ISA: TEST72.isa
+    Inst: TEST72.inst42
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 42
+  - PseudoInst: TEST72.pinst43
+    ISA: TEST72.isa
+    Inst: TEST72.inst43
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 43
+  - PseudoInst: TEST72.pinst44
+    ISA: TEST72.isa
+    Inst: TEST72.inst44
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 44
+  - PseudoInst: TEST72.pinst45
+    ISA: TEST72.isa
+    Inst: TEST72.inst45
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 45
+  - PseudoInst: TEST72.pinst46
+    ISA: TEST72.isa
+    Inst: TEST72.inst46
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 46
+  - PseudoInst: TEST72.pinst47
+    ISA: TEST72.isa
+    Inst: TEST72.inst47
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 47
+  - PseudoInst: TEST72.pinst48
+    ISA: TEST72.isa
+    Inst: TEST72.inst48
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 48
+  - PseudoInst: TEST72.pinst49
+    ISA: TEST72.isa
+    Inst: TEST72.inst49
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 49
+  - PseudoInst: TEST72.pinst50
+    ISA: TEST72.isa
+    Inst: TEST72.inst50
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 50
+  - PseudoInst: TEST72.pinst51
+    ISA: TEST72.isa
+    Inst: TEST72.inst51
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 51
+  - PseudoInst: TEST72.pinst52
+    ISA: TEST72.isa
+    Inst: TEST72.inst52
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 52
+  - PseudoInst: TEST72.pinst53
+    ISA: TEST72.isa
+    Inst: TEST72.inst53
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 53
+  - PseudoInst: TEST72.pinst54
+    ISA: TEST72.isa
+    Inst: TEST72.inst54
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 54
+  - PseudoInst: TEST72.pinst55
+    ISA: TEST72.isa
+    Inst: TEST72.inst55
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 55
+  - PseudoInst: TEST72.pinst56
+    ISA: TEST72.isa
+    Inst: TEST72.inst56
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 56
+  - PseudoInst: TEST72.pinst57
+    ISA: TEST72.isa
+    Inst: TEST72.inst57
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 57
+  - PseudoInst: TEST72.pinst58
+    ISA: TEST72.isa
+    Inst: TEST72.inst58
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 58
+  - PseudoInst: TEST72.pinst59
+    ISA: TEST72.isa
+    Inst: TEST72.inst59
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 59
+  - PseudoInst: TEST72.pinst60
+    ISA: TEST72.isa
+    Inst: TEST72.inst60
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 60
+  - PseudoInst: TEST72.pinst61
+    ISA: TEST72.isa
+    Inst: TEST72.inst61
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 61
+  - PseudoInst: TEST72.pinst62
+    ISA: TEST72.isa
+    Inst: TEST72.inst62
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 62
+  - PseudoInst: TEST72.pinst63
+    ISA: TEST72.isa
+    Inst: TEST72.inst63
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 63
+  - PseudoInst: TEST72.pinst64
+    ISA: TEST72.isa
+    Inst: TEST72.inst64
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 64
+  - PseudoInst: TEST72.pinst65
+    ISA: TEST72.isa
+    Inst: TEST72.inst65
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 65
+  - PseudoInst: TEST72.pinst66
+    ISA: TEST72.isa
+    Inst: TEST72.inst66
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 66
+  - PseudoInst: TEST72.pinst67
+    ISA: TEST72.isa
+    Inst: TEST72.inst67
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 67
+  - PseudoInst: TEST72.pinst68
+    ISA: TEST72.isa
+    Inst: TEST72.inst68
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 68
+  - PseudoInst: TEST72.pinst69
+    ISA: TEST72.isa
+    Inst: TEST72.inst69
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 69
+  - PseudoInst: TEST72.pinst70
+    ISA: TEST72.isa
+    Inst: TEST72.inst70
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 70
+  - PseudoInst: TEST72.pinst71
+    ISA: TEST72.isa
+    Inst: TEST72.inst71
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 71
+Caches:
+  - Cache: TEST72.L2.cache
+    Sets: 2
+    Ways: 8
+  - Cache: TEST72.core0.L1.cache
+    Sets: 1
+    Ways: 1
+    SubLevel: TEST72.L2.cache
+  - Cache: TEST72.L2.cache
+    Sets: 2
+    Ways: 8
+  - Cache: TEST72.core1.L1.cache
+    Sets: 1
+    Ways: 1
+    SubLevel: TEST72.L2.cache
+  - Cache: TEST72.L2.cache
+    Sets: 2
+    Ways: 8
+  - Cache: TEST72.core2.L1.cache
+    Sets: 1
+    Ways: 1
+    SubLevel: TEST72.L2.cache
+  - Cache: TEST72.L2.cache
+    Sets: 2
+    Ways: 8
+  - Cache: TEST72.core3.L1.cache
+    Sets: 1
+    Ways: 1
+    SubLevel: TEST72.L2.cache
+  - Cache: TEST72.L2.cache
+    Sets: 2
+    Ways: 8
+Comms:
+  - Comm: TEST72.comm
+    Type: NOC
+    Width: 64
+    Endpoints:
+      - TEST72.core0
+      - TEST72.core1
+      - TEST72.core2
+      - TEST72.core3
+      - TEST72.L2.cache
+      - TEST72.vtp
+      - TEST72.0.mctrl
+      - TEST72.1.mctrl
+      - TEST72.2.mctrl
+      - TEST72.3.mctrl
+Scratchpads:
+  - Scratchpad: TEST72.0.spad
+    MemSize: 1024
+    RqstPorts: 1
+    RspPorts: 1
+    StartAddr: 34359739392
+  - Scratchpad: TEST72.1.spad
+    MemSize: 2048
+    RqstPorts: 1
+    RspPorts: 1
+    StartAddr: 34359740416
+  - Scratchpad: TEST72.2.spad
+    MemSize: 3072
+    RqstPorts: 1
+    RspPorts: 1
+    StartAddr: 34359741440
+  - Scratchpad: TEST72.3.spad
+    MemSize: 4096
+    RqstPorts: 1
+    RspPorts: 1
+    StartAddr: 34359742464
+MemoryControllers:
+  - MemoryController: TEST72.0.mctrl
+    Ports: 2
+  - MemoryController: TEST72.1.mctrl
+    Ports: 2
+  - MemoryController: TEST72.2.mctrl
+    Ports: 2
+  - MemoryController: TEST72.3.mctrl
+    Ports: 2
+VTPControllers:
+  - VTP: TEST72.vtp
+Extensions:
+  - Extension: TEST72.ext0
+    Type: unknown
+    Registers:
+      - RegName: TEST72.ext0.reg
+        Width: 64
+        Index: 0
+        IsFixedValue: false
+        IsSIMD: false
+        RWReg: false
+        ROReg: false
+        CSRReg: true
+        AMSReg: false
+        TUSReg: false
+        Shared: false
+    RegClasses:
+      - RegisterClassName: TEST72.ext0.regclass
+        Registers:
+          - TEST72.ext0.reg
+    ISAs:
+      - ISAName: TEST72.ext0.isa
+    RTLFile: TEST72.ext0.v
+  - Extension: TEST72.ext1
+    Type: unknown
+    Registers:
+      - RegName: TEST72.ext1.reg
+        Width: 64
+        Index: 0
+        IsFixedValue: false
+        IsSIMD: false
+        RWReg: false
+        ROReg: false
+        CSRReg: true
+        AMSReg: false
+        TUSReg: false
+        Shared: false
+    RegClasses:
+      - RegisterClassName: TEST72.ext1.regclass
+        Registers:
+          - TEST72.ext1.reg
+    ISAs:
+      - ISAName: TEST72.ext1.isa
+    RTLFile: TEST72.ext1.v
+  - Extension: TEST72.ext2
+    Type: unknown
+    Registers:
+      - RegName: TEST72.ext2.reg
+        Width: 64
+        Index: 0
+        IsFixedValue: false
+        IsSIMD: false
+        RWReg: false
+        ROReg: false
+        CSRReg: true
+        AMSReg: false
+        TUSReg: false
+        Shared: false
+    RegClasses:
+      - RegisterClassName: TEST72.ext2.regclass
+        Registers:
+          - TEST72.ext2.reg
+    ISAs:
+      - ISAName: TEST72.ext2.isa
+    RTLFile: TEST72.ext2.v
+  - Extension: TEST72.ext3
+    Type: unknown
+    Registers:
+      - RegName: TEST72.ext3.reg
+        Width: 64
+        Index: 0
+        IsFixedValue: false
+        IsSIMD: false
+        RWReg: false
+        ROReg: false
+        CSRReg: true
+        AMSReg: false
+        TUSReg: false
+        Shared: false
+    RegClasses:
+      - RegisterClassName: TEST72.ext3.regclass
+        Registers:
+          - TEST72.ext3.reg
+    ISAs:
+      - ISAName: TEST72.ext3.isa
+    RTLFile: TEST72.ext3.v
+Cores:
+  - Core: TEST72.core0
+    ThreadUnits: 1
+    Cache: TEST72.core0.L1.cache
+    ISA: TEST72.isa
+    RegisterClasses:
+      - RegClass: TEST72.regclass
+      - RegClass: TEST72.csrregclass
+    Extensions:
+      - Extension: TEST72.ext0
+  - Core: TEST72.core1
+    ThreadUnits: 2
+    Cache: TEST72.core1.L1.cache
+    ISA: TEST72.isa
+    RegisterClasses:
+      - RegClass: TEST72.regclass
+      - RegClass: TEST72.csrregclass
+    Extensions:
+      - Extension: TEST72.ext1
+  - Core: TEST72.core2
+    ThreadUnits: 3
+    Cache: TEST72.core2.L1.cache
+    ISA: TEST72.isa
+    RegisterClasses:
+      - RegClass: TEST72.regclass
+      - RegClass: TEST72.csrregclass
+    Extensions:
+      - Extension: TEST72.ext2
+  - Core: TEST72.core3
+    ThreadUnits: 4
+    Cache: TEST72.core3.L1.cache
+    ISA: TEST72.isa
+    RegisterClasses:
+      - RegClass: TEST72.regclass
+      - RegClass: TEST72.csrregclass
+    Extensions:
+      - Extension: TEST72.ext3
+Socs:
+  - Soc: TEST72.soc
+    Cores:
+      - Core: TEST72.core0
+      - Core: TEST72.core1
+      - Core: TEST72.core2
+      - Core: TEST72.core3

--- a/test/Yaml/Reader/MissingData/TEST38.yaml
+++ b/test/Yaml/Reader/MissingData/TEST38.yaml
@@ -1,0 +1,3143 @@
+ProjectInfo:
+  - ProjectName: TEST72
+    ProjectRoot: ./
+    ProjectType: unknown
+    ChiselMajorVersion: 3
+    ChiselMinorVersion: 0
+Registers:
+  - RegName: TEST72.0.reg
+    Width: 64
+    Index: 0
+    PseudoName: pseudoreg.0
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+    SubRegs:
+      - SubReg: SUBREG0
+        StartBit: 0
+        EndBit:
+      - SubReg: SUBREG1
+        StartBit: 32
+        EndBit: 63
+  - RegName: TEST72.1.reg
+    Width: 64
+    Index: 1
+    PseudoName: pseudoreg.1
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.2.reg
+    Width: 64
+    Index: 2
+    PseudoName: pseudoreg.2
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.3.reg
+    Width: 64
+    Index: 3
+    PseudoName: pseudoreg.3
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.4.reg
+    Width: 64
+    Index: 4
+    PseudoName: pseudoreg.4
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.5.reg
+    Width: 64
+    Index: 5
+    PseudoName: pseudoreg.5
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.6.reg
+    Width: 64
+    Index: 6
+    PseudoName: pseudoreg.6
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.7.reg
+    Width: 64
+    Index: 7
+    PseudoName: pseudoreg.7
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.8.reg
+    Width: 64
+    Index: 8
+    PseudoName: pseudoreg.8
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.9.reg
+    Width: 64
+    Index: 9
+    PseudoName: pseudoreg.9
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.10.reg
+    Width: 64
+    Index: 10
+    PseudoName: pseudoreg.10
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.11.reg
+    Width: 64
+    Index: 11
+    PseudoName: pseudoreg.11
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.12.reg
+    Width: 64
+    Index: 12
+    PseudoName: pseudoreg.12
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.13.reg
+    Width: 64
+    Index: 13
+    PseudoName: pseudoreg.13
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.14.reg
+    Width: 64
+    Index: 14
+    PseudoName: pseudoreg.14
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.15.reg
+    Width: 64
+    Index: 15
+    PseudoName: pseudoreg.15
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.16.reg
+    Width: 64
+    Index: 16
+    PseudoName: pseudoreg.16
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.17.reg
+    Width: 64
+    Index: 17
+    PseudoName: pseudoreg.17
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.18.reg
+    Width: 64
+    Index: 18
+    PseudoName: pseudoreg.18
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.19.reg
+    Width: 64
+    Index: 19
+    PseudoName: pseudoreg.19
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.20.reg
+    Width: 64
+    Index: 20
+    PseudoName: pseudoreg.20
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.21.reg
+    Width: 64
+    Index: 21
+    PseudoName: pseudoreg.21
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.22.reg
+    Width: 64
+    Index: 22
+    PseudoName: pseudoreg.22
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.23.reg
+    Width: 64
+    Index: 23
+    PseudoName: pseudoreg.23
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.24.reg
+    Width: 64
+    Index: 24
+    PseudoName: pseudoreg.24
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.25.reg
+    Width: 64
+    Index: 25
+    PseudoName: pseudoreg.25
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.26.reg
+    Width: 64
+    Index: 26
+    PseudoName: pseudoreg.26
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.27.reg
+    Width: 64
+    Index: 27
+    PseudoName: pseudoreg.27
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.28.reg
+    Width: 64
+    Index: 28
+    PseudoName: pseudoreg.28
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.29.reg
+    Width: 64
+    Index: 29
+    PseudoName: pseudoreg.29
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.30.reg
+    Width: 64
+    Index: 30
+    PseudoName: pseudoreg.30
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.31.reg
+    Width: 64
+    Index: 31
+    PseudoName: pseudoreg.31
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.32.reg
+    Width: 64
+    Index: 32
+    PseudoName: pseudoreg.32
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.33.reg
+    Width: 64
+    Index: 33
+    PseudoName: pseudoreg.33
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.34.reg
+    Width: 64
+    Index: 34
+    PseudoName: pseudoreg.34
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.35.reg
+    Width: 64
+    Index: 35
+    PseudoName: pseudoreg.35
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.36.reg
+    Width: 64
+    Index: 36
+    PseudoName: pseudoreg.36
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.37.reg
+    Width: 64
+    Index: 37
+    PseudoName: pseudoreg.37
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.38.reg
+    Width: 64
+    Index: 38
+    PseudoName: pseudoreg.38
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.39.reg
+    Width: 64
+    Index: 39
+    PseudoName: pseudoreg.39
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.40.reg
+    Width: 64
+    Index: 40
+    PseudoName: pseudoreg.40
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.41.reg
+    Width: 64
+    Index: 41
+    PseudoName: pseudoreg.41
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.42.reg
+    Width: 64
+    Index: 42
+    PseudoName: pseudoreg.42
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.43.reg
+    Width: 64
+    Index: 43
+    PseudoName: pseudoreg.43
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.44.reg
+    Width: 64
+    Index: 44
+    PseudoName: pseudoreg.44
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.45.reg
+    Width: 64
+    Index: 45
+    PseudoName: pseudoreg.45
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.46.reg
+    Width: 64
+    Index: 46
+    PseudoName: pseudoreg.46
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.47.reg
+    Width: 64
+    Index: 47
+    PseudoName: pseudoreg.47
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.48.reg
+    Width: 64
+    Index: 48
+    PseudoName: pseudoreg.48
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.49.reg
+    Width: 64
+    Index: 49
+    PseudoName: pseudoreg.49
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.50.reg
+    Width: 64
+    Index: 50
+    PseudoName: pseudoreg.50
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.51.reg
+    Width: 64
+    Index: 51
+    PseudoName: pseudoreg.51
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.52.reg
+    Width: 64
+    Index: 52
+    PseudoName: pseudoreg.52
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.53.reg
+    Width: 64
+    Index: 53
+    PseudoName: pseudoreg.53
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.54.reg
+    Width: 64
+    Index: 54
+    PseudoName: pseudoreg.54
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.55.reg
+    Width: 64
+    Index: 55
+    PseudoName: pseudoreg.55
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.56.reg
+    Width: 64
+    Index: 56
+    PseudoName: pseudoreg.56
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.57.reg
+    Width: 64
+    Index: 57
+    PseudoName: pseudoreg.57
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.58.reg
+    Width: 64
+    Index: 58
+    PseudoName: pseudoreg.58
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.59.reg
+    Width: 64
+    Index: 59
+    PseudoName: pseudoreg.59
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.60.reg
+    Width: 64
+    Index: 60
+    PseudoName: pseudoreg.60
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.61.reg
+    Width: 64
+    Index: 61
+    PseudoName: pseudoreg.61
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.62.reg
+    Width: 64
+    Index: 62
+    PseudoName: pseudoreg.62
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.63.reg
+    Width: 64
+    Index: 63
+    PseudoName: pseudoreg.63
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.64.reg
+    Width: 64
+    Index: 64
+    PseudoName: pseudoreg.64
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.65.reg
+    Width: 64
+    Index: 65
+    PseudoName: pseudoreg.65
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.66.reg
+    Width: 64
+    Index: 66
+    PseudoName: pseudoreg.66
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.67.reg
+    Width: 64
+    Index: 67
+    PseudoName: pseudoreg.67
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.68.reg
+    Width: 64
+    Index: 68
+    PseudoName: pseudoreg.68
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.69.reg
+    Width: 64
+    Index: 69
+    PseudoName: pseudoreg.69
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.70.reg
+    Width: 64
+    Index: 70
+    PseudoName: pseudoreg.70
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.71.reg
+    Width: 64
+    Index: 71
+    PseudoName: pseudoreg.71
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.0.csr
+    Width: 64
+    Index: 0
+    PseudoName: csr.0
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.1.csr
+    Width: 64
+    Index: 1
+    PseudoName: csr.1
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.2.csr
+    Width: 64
+    Index: 2
+    PseudoName: csr.2
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.3.csr
+    Width: 64
+    Index: 3
+    PseudoName: csr.3
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.4.csr
+    Width: 64
+    Index: 4
+    PseudoName: csr.4
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.5.csr
+    Width: 64
+    Index: 5
+    PseudoName: csr.5
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.6.csr
+    Width: 64
+    Index: 6
+    PseudoName: csr.6
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.7.csr
+    Width: 64
+    Index: 7
+    PseudoName: csr.7
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.8.csr
+    Width: 64
+    Index: 8
+    PseudoName: csr.8
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.9.csr
+    Width: 64
+    Index: 9
+    PseudoName: csr.9
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.10.csr
+    Width: 64
+    Index: 10
+    PseudoName: csr.10
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.11.csr
+    Width: 64
+    Index: 11
+    PseudoName: csr.11
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.12.csr
+    Width: 64
+    Index: 12
+    PseudoName: csr.12
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.13.csr
+    Width: 64
+    Index: 13
+    PseudoName: csr.13
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.14.csr
+    Width: 64
+    Index: 14
+    PseudoName: csr.14
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.15.csr
+    Width: 64
+    Index: 15
+    PseudoName: csr.15
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.16.csr
+    Width: 64
+    Index: 16
+    PseudoName: csr.16
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.17.csr
+    Width: 64
+    Index: 17
+    PseudoName: csr.17
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.18.csr
+    Width: 64
+    Index: 18
+    PseudoName: csr.18
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.19.csr
+    Width: 64
+    Index: 19
+    PseudoName: csr.19
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.20.csr
+    Width: 64
+    Index: 20
+    PseudoName: csr.20
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.21.csr
+    Width: 64
+    Index: 21
+    PseudoName: csr.21
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.22.csr
+    Width: 64
+    Index: 22
+    PseudoName: csr.22
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.23.csr
+    Width: 64
+    Index: 23
+    PseudoName: csr.23
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.24.csr
+    Width: 64
+    Index: 24
+    PseudoName: csr.24
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.25.csr
+    Width: 64
+    Index: 25
+    PseudoName: csr.25
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.26.csr
+    Width: 64
+    Index: 26
+    PseudoName: csr.26
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.27.csr
+    Width: 64
+    Index: 27
+    PseudoName: csr.27
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.28.csr
+    Width: 64
+    Index: 28
+    PseudoName: csr.28
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.29.csr
+    Width: 64
+    Index: 29
+    PseudoName: csr.29
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.30.csr
+    Width: 64
+    Index: 30
+    PseudoName: csr.30
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.31.csr
+    Width: 64
+    Index: 31
+    PseudoName: csr.31
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.32.csr
+    Width: 64
+    Index: 32
+    PseudoName: csr.32
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.33.csr
+    Width: 64
+    Index: 33
+    PseudoName: csr.33
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.34.csr
+    Width: 64
+    Index: 34
+    PseudoName: csr.34
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.35.csr
+    Width: 64
+    Index: 35
+    PseudoName: csr.35
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.36.csr
+    Width: 64
+    Index: 36
+    PseudoName: csr.36
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.37.csr
+    Width: 64
+    Index: 37
+    PseudoName: csr.37
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.38.csr
+    Width: 64
+    Index: 38
+    PseudoName: csr.38
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.39.csr
+    Width: 64
+    Index: 39
+    PseudoName: csr.39
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.40.csr
+    Width: 64
+    Index: 40
+    PseudoName: csr.40
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.41.csr
+    Width: 64
+    Index: 41
+    PseudoName: csr.41
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.42.csr
+    Width: 64
+    Index: 42
+    PseudoName: csr.42
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.43.csr
+    Width: 64
+    Index: 43
+    PseudoName: csr.43
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.44.csr
+    Width: 64
+    Index: 44
+    PseudoName: csr.44
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.45.csr
+    Width: 64
+    Index: 45
+    PseudoName: csr.45
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.46.csr
+    Width: 64
+    Index: 46
+    PseudoName: csr.46
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.47.csr
+    Width: 64
+    Index: 47
+    PseudoName: csr.47
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.48.csr
+    Width: 64
+    Index: 48
+    PseudoName: csr.48
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.49.csr
+    Width: 64
+    Index: 49
+    PseudoName: csr.49
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.50.csr
+    Width: 64
+    Index: 50
+    PseudoName: csr.50
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.51.csr
+    Width: 64
+    Index: 51
+    PseudoName: csr.51
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.52.csr
+    Width: 64
+    Index: 52
+    PseudoName: csr.52
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.53.csr
+    Width: 64
+    Index: 53
+    PseudoName: csr.53
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.54.csr
+    Width: 64
+    Index: 54
+    PseudoName: csr.54
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.55.csr
+    Width: 64
+    Index: 55
+    PseudoName: csr.55
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.56.csr
+    Width: 64
+    Index: 56
+    PseudoName: csr.56
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.57.csr
+    Width: 64
+    Index: 57
+    PseudoName: csr.57
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.58.csr
+    Width: 64
+    Index: 58
+    PseudoName: csr.58
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.59.csr
+    Width: 64
+    Index: 59
+    PseudoName: csr.59
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.60.csr
+    Width: 64
+    Index: 60
+    PseudoName: csr.60
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.61.csr
+    Width: 64
+    Index: 61
+    PseudoName: csr.61
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.62.csr
+    Width: 64
+    Index: 62
+    PseudoName: csr.62
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.63.csr
+    Width: 64
+    Index: 63
+    PseudoName: csr.63
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.64.csr
+    Width: 64
+    Index: 64
+    PseudoName: csr.64
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.65.csr
+    Width: 64
+    Index: 65
+    PseudoName: csr.65
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.66.csr
+    Width: 64
+    Index: 66
+    PseudoName: csr.66
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.67.csr
+    Width: 64
+    Index: 67
+    PseudoName: csr.67
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.68.csr
+    Width: 64
+    Index: 68
+    PseudoName: csr.68
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.69.csr
+    Width: 64
+    Index: 69
+    PseudoName: csr.69
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.70.csr
+    Width: 64
+    Index: 70
+    PseudoName: csr.70
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.71.csr
+    Width: 64
+    Index: 71
+    PseudoName: csr.71
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+RegClasses:
+  - RegisterClassName: TEST72.regclass
+    Registers:
+      - TEST72.0.reg
+      - TEST72.1.reg
+      - TEST72.2.reg
+      - TEST72.3.reg
+      - TEST72.4.reg
+      - TEST72.5.reg
+      - TEST72.6.reg
+      - TEST72.7.reg
+      - TEST72.8.reg
+      - TEST72.9.reg
+      - TEST72.10.reg
+      - TEST72.11.reg
+      - TEST72.12.reg
+      - TEST72.13.reg
+      - TEST72.14.reg
+      - TEST72.15.reg
+      - TEST72.16.reg
+      - TEST72.17.reg
+      - TEST72.18.reg
+      - TEST72.19.reg
+      - TEST72.20.reg
+      - TEST72.21.reg
+      - TEST72.22.reg
+      - TEST72.23.reg
+      - TEST72.24.reg
+      - TEST72.25.reg
+      - TEST72.26.reg
+      - TEST72.27.reg
+      - TEST72.28.reg
+      - TEST72.29.reg
+      - TEST72.30.reg
+      - TEST72.31.reg
+      - TEST72.32.reg
+      - TEST72.33.reg
+      - TEST72.34.reg
+      - TEST72.35.reg
+      - TEST72.36.reg
+      - TEST72.37.reg
+      - TEST72.38.reg
+      - TEST72.39.reg
+      - TEST72.40.reg
+      - TEST72.41.reg
+      - TEST72.42.reg
+      - TEST72.43.reg
+      - TEST72.44.reg
+      - TEST72.45.reg
+      - TEST72.46.reg
+      - TEST72.47.reg
+      - TEST72.48.reg
+      - TEST72.49.reg
+      - TEST72.50.reg
+      - TEST72.51.reg
+      - TEST72.52.reg
+      - TEST72.53.reg
+      - TEST72.54.reg
+      - TEST72.55.reg
+      - TEST72.56.reg
+      - TEST72.57.reg
+      - TEST72.58.reg
+      - TEST72.59.reg
+      - TEST72.60.reg
+      - TEST72.61.reg
+      - TEST72.62.reg
+      - TEST72.63.reg
+      - TEST72.64.reg
+      - TEST72.65.reg
+      - TEST72.66.reg
+      - TEST72.67.reg
+      - TEST72.68.reg
+      - TEST72.69.reg
+      - TEST72.70.reg
+      - TEST72.71.reg
+  - RegisterClassName: TEST72.csrregclass
+    Registers:
+      - TEST72.0.csr
+      - TEST72.1.csr
+      - TEST72.2.csr
+      - TEST72.3.csr
+      - TEST72.4.csr
+      - TEST72.5.csr
+      - TEST72.6.csr
+      - TEST72.7.csr
+      - TEST72.8.csr
+      - TEST72.9.csr
+      - TEST72.10.csr
+      - TEST72.11.csr
+      - TEST72.12.csr
+      - TEST72.13.csr
+      - TEST72.14.csr
+      - TEST72.15.csr
+      - TEST72.16.csr
+      - TEST72.17.csr
+      - TEST72.18.csr
+      - TEST72.19.csr
+      - TEST72.20.csr
+      - TEST72.21.csr
+      - TEST72.22.csr
+      - TEST72.23.csr
+      - TEST72.24.csr
+      - TEST72.25.csr
+      - TEST72.26.csr
+      - TEST72.27.csr
+      - TEST72.28.csr
+      - TEST72.29.csr
+      - TEST72.30.csr
+      - TEST72.31.csr
+      - TEST72.32.csr
+      - TEST72.33.csr
+      - TEST72.34.csr
+      - TEST72.35.csr
+      - TEST72.36.csr
+      - TEST72.37.csr
+      - TEST72.38.csr
+      - TEST72.39.csr
+      - TEST72.40.csr
+      - TEST72.41.csr
+      - TEST72.42.csr
+      - TEST72.43.csr
+      - TEST72.44.csr
+      - TEST72.45.csr
+      - TEST72.46.csr
+      - TEST72.47.csr
+      - TEST72.48.csr
+      - TEST72.49.csr
+      - TEST72.50.csr
+      - TEST72.51.csr
+      - TEST72.52.csr
+      - TEST72.53.csr
+      - TEST72.54.csr
+      - TEST72.55.csr
+      - TEST72.56.csr
+      - TEST72.57.csr
+      - TEST72.58.csr
+      - TEST72.59.csr
+      - TEST72.60.csr
+      - TEST72.61.csr
+      - TEST72.62.csr
+      - TEST72.63.csr
+      - TEST72.64.csr
+      - TEST72.65.csr
+      - TEST72.66.csr
+      - TEST72.67.csr
+      - TEST72.68.csr
+      - TEST72.69.csr
+      - TEST72.70.csr
+      - TEST72.71.csr
+ISAs:
+  - ISAName: TEST72.isa
+InstFormats:
+  - InstFormatName: TEST72.if
+    ISA: TEST72.isa
+    FormatWidth: 32
+    Fields:
+      - FieldName: opcode
+        FieldType: CGInstCode
+        FieldWidth: 8
+        StartBit: 0
+        EndBit: 7
+        MandatoryField: true
+      - FieldName: RB
+        FieldType: CGInstReg
+        FieldWidth: 8
+        StartBit: 8
+        EndBit: 15
+        MandatoryField: false
+        RegClass: TEST72.regclass
+      - FieldName: RA
+        FieldType: CGInstReg
+        FieldWidth: 8
+        StartBit: 16
+        EndBit: 23
+        MandatoryField: false
+        RegClass: TEST72.regclass
+      - FieldName: RT
+        FieldType: CGInstReg
+        FieldWidth: 8
+        StartBit: 24
+        EndBit: 31
+        MandatoryField: false
+        RegClass: TEST72.csrregclass
+Insts:
+  - Inst: TEST72.inst0
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 1
+  - Inst: TEST72.inst1
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 2
+  - Inst: TEST72.inst2
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 3
+  - Inst: TEST72.inst3
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 4
+  - Inst: TEST72.inst4
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 5
+  - Inst: TEST72.inst5
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 6
+  - Inst: TEST72.inst6
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 7
+  - Inst: TEST72.inst7
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 8
+  - Inst: TEST72.inst8
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 9
+  - Inst: TEST72.inst9
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 10
+  - Inst: TEST72.inst10
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 11
+  - Inst: TEST72.inst11
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 12
+  - Inst: TEST72.inst12
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 13
+  - Inst: TEST72.inst13
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 14
+  - Inst: TEST72.inst14
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 15
+  - Inst: TEST72.inst15
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 16
+  - Inst: TEST72.inst16
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 17
+  - Inst: TEST72.inst17
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 18
+  - Inst: TEST72.inst18
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 19
+  - Inst: TEST72.inst19
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 20
+  - Inst: TEST72.inst20
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 21
+  - Inst: TEST72.inst21
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 22
+  - Inst: TEST72.inst22
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 23
+  - Inst: TEST72.inst23
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 24
+  - Inst: TEST72.inst24
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 25
+  - Inst: TEST72.inst25
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 26
+  - Inst: TEST72.inst26
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 27
+  - Inst: TEST72.inst27
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 28
+  - Inst: TEST72.inst28
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 29
+  - Inst: TEST72.inst29
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 30
+  - Inst: TEST72.inst30
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 31
+  - Inst: TEST72.inst31
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 32
+  - Inst: TEST72.inst32
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 33
+  - Inst: TEST72.inst33
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 34
+  - Inst: TEST72.inst34
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 35
+  - Inst: TEST72.inst35
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 36
+  - Inst: TEST72.inst36
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 37
+  - Inst: TEST72.inst37
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 38
+  - Inst: TEST72.inst38
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 39
+  - Inst: TEST72.inst39
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 40
+  - Inst: TEST72.inst40
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 41
+  - Inst: TEST72.inst41
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 42
+  - Inst: TEST72.inst42
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 43
+  - Inst: TEST72.inst43
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 44
+  - Inst: TEST72.inst44
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 45
+  - Inst: TEST72.inst45
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 46
+  - Inst: TEST72.inst46
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 47
+  - Inst: TEST72.inst47
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 48
+  - Inst: TEST72.inst48
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 49
+  - Inst: TEST72.inst49
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 50
+  - Inst: TEST72.inst50
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 51
+  - Inst: TEST72.inst51
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 52
+  - Inst: TEST72.inst52
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 53
+  - Inst: TEST72.inst53
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 54
+  - Inst: TEST72.inst54
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 55
+  - Inst: TEST72.inst55
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 56
+  - Inst: TEST72.inst56
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 57
+  - Inst: TEST72.inst57
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 58
+  - Inst: TEST72.inst58
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 59
+  - Inst: TEST72.inst59
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 60
+  - Inst: TEST72.inst60
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 61
+  - Inst: TEST72.inst61
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 62
+  - Inst: TEST72.inst62
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 63
+  - Inst: TEST72.inst63
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 64
+  - Inst: TEST72.inst64
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 65
+  - Inst: TEST72.inst65
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 66
+  - Inst: TEST72.inst66
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 67
+  - Inst: TEST72.inst67
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 68
+  - Inst: TEST72.inst68
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 69
+  - Inst: TEST72.inst69
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 70
+  - Inst: TEST72.inst70
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 71
+  - Inst: TEST72.inst71
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 72
+PseudoInsts:
+  - PseudoInst: TEST72.pinst0
+    ISA: TEST72.isa
+    Inst: TEST72.inst0
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 0
+  - PseudoInst: TEST72.pinst1
+    ISA: TEST72.isa
+    Inst: TEST72.inst1
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 1
+  - PseudoInst: TEST72.pinst2
+    ISA: TEST72.isa
+    Inst: TEST72.inst2
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 2
+  - PseudoInst: TEST72.pinst3
+    ISA: TEST72.isa
+    Inst: TEST72.inst3
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 3
+  - PseudoInst: TEST72.pinst4
+    ISA: TEST72.isa
+    Inst: TEST72.inst4
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 4
+  - PseudoInst: TEST72.pinst5
+    ISA: TEST72.isa
+    Inst: TEST72.inst5
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 5
+  - PseudoInst: TEST72.pinst6
+    ISA: TEST72.isa
+    Inst: TEST72.inst6
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 6
+  - PseudoInst: TEST72.pinst7
+    ISA: TEST72.isa
+    Inst: TEST72.inst7
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 7
+  - PseudoInst: TEST72.pinst8
+    ISA: TEST72.isa
+    Inst: TEST72.inst8
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 8
+  - PseudoInst: TEST72.pinst9
+    ISA: TEST72.isa
+    Inst: TEST72.inst9
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 9
+  - PseudoInst: TEST72.pinst10
+    ISA: TEST72.isa
+    Inst: TEST72.inst10
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 10
+  - PseudoInst: TEST72.pinst11
+    ISA: TEST72.isa
+    Inst: TEST72.inst11
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 11
+  - PseudoInst: TEST72.pinst12
+    ISA: TEST72.isa
+    Inst: TEST72.inst12
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 12
+  - PseudoInst: TEST72.pinst13
+    ISA: TEST72.isa
+    Inst: TEST72.inst13
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 13
+  - PseudoInst: TEST72.pinst14
+    ISA: TEST72.isa
+    Inst: TEST72.inst14
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 14
+  - PseudoInst: TEST72.pinst15
+    ISA: TEST72.isa
+    Inst: TEST72.inst15
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 15
+  - PseudoInst: TEST72.pinst16
+    ISA: TEST72.isa
+    Inst: TEST72.inst16
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 16
+  - PseudoInst: TEST72.pinst17
+    ISA: TEST72.isa
+    Inst: TEST72.inst17
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 17
+  - PseudoInst: TEST72.pinst18
+    ISA: TEST72.isa
+    Inst: TEST72.inst18
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 18
+  - PseudoInst: TEST72.pinst19
+    ISA: TEST72.isa
+    Inst: TEST72.inst19
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 19
+  - PseudoInst: TEST72.pinst20
+    ISA: TEST72.isa
+    Inst: TEST72.inst20
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 20
+  - PseudoInst: TEST72.pinst21
+    ISA: TEST72.isa
+    Inst: TEST72.inst21
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 21
+  - PseudoInst: TEST72.pinst22
+    ISA: TEST72.isa
+    Inst: TEST72.inst22
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 22
+  - PseudoInst: TEST72.pinst23
+    ISA: TEST72.isa
+    Inst: TEST72.inst23
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 23
+  - PseudoInst: TEST72.pinst24
+    ISA: TEST72.isa
+    Inst: TEST72.inst24
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 24
+  - PseudoInst: TEST72.pinst25
+    ISA: TEST72.isa
+    Inst: TEST72.inst25
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 25
+  - PseudoInst: TEST72.pinst26
+    ISA: TEST72.isa
+    Inst: TEST72.inst26
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 26
+  - PseudoInst: TEST72.pinst27
+    ISA: TEST72.isa
+    Inst: TEST72.inst27
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 27
+  - PseudoInst: TEST72.pinst28
+    ISA: TEST72.isa
+    Inst: TEST72.inst28
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 28
+  - PseudoInst: TEST72.pinst29
+    ISA: TEST72.isa
+    Inst: TEST72.inst29
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 29
+  - PseudoInst: TEST72.pinst30
+    ISA: TEST72.isa
+    Inst: TEST72.inst30
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 30
+  - PseudoInst: TEST72.pinst31
+    ISA: TEST72.isa
+    Inst: TEST72.inst31
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 31
+  - PseudoInst: TEST72.pinst32
+    ISA: TEST72.isa
+    Inst: TEST72.inst32
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 32
+  - PseudoInst: TEST72.pinst33
+    ISA: TEST72.isa
+    Inst: TEST72.inst33
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 33
+  - PseudoInst: TEST72.pinst34
+    ISA: TEST72.isa
+    Inst: TEST72.inst34
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 34
+  - PseudoInst: TEST72.pinst35
+    ISA: TEST72.isa
+    Inst: TEST72.inst35
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 35
+  - PseudoInst: TEST72.pinst36
+    ISA: TEST72.isa
+    Inst: TEST72.inst36
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 36
+  - PseudoInst: TEST72.pinst37
+    ISA: TEST72.isa
+    Inst: TEST72.inst37
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 37
+  - PseudoInst: TEST72.pinst38
+    ISA: TEST72.isa
+    Inst: TEST72.inst38
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 38
+  - PseudoInst: TEST72.pinst39
+    ISA: TEST72.isa
+    Inst: TEST72.inst39
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 39
+  - PseudoInst: TEST72.pinst40
+    ISA: TEST72.isa
+    Inst: TEST72.inst40
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 40
+  - PseudoInst: TEST72.pinst41
+    ISA: TEST72.isa
+    Inst: TEST72.inst41
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 41
+  - PseudoInst: TEST72.pinst42
+    ISA: TEST72.isa
+    Inst: TEST72.inst42
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 42
+  - PseudoInst: TEST72.pinst43
+    ISA: TEST72.isa
+    Inst: TEST72.inst43
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 43
+  - PseudoInst: TEST72.pinst44
+    ISA: TEST72.isa
+    Inst: TEST72.inst44
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 44
+  - PseudoInst: TEST72.pinst45
+    ISA: TEST72.isa
+    Inst: TEST72.inst45
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 45
+  - PseudoInst: TEST72.pinst46
+    ISA: TEST72.isa
+    Inst: TEST72.inst46
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 46
+  - PseudoInst: TEST72.pinst47
+    ISA: TEST72.isa
+    Inst: TEST72.inst47
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 47
+  - PseudoInst: TEST72.pinst48
+    ISA: TEST72.isa
+    Inst: TEST72.inst48
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 48
+  - PseudoInst: TEST72.pinst49
+    ISA: TEST72.isa
+    Inst: TEST72.inst49
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 49
+  - PseudoInst: TEST72.pinst50
+    ISA: TEST72.isa
+    Inst: TEST72.inst50
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 50
+  - PseudoInst: TEST72.pinst51
+    ISA: TEST72.isa
+    Inst: TEST72.inst51
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 51
+  - PseudoInst: TEST72.pinst52
+    ISA: TEST72.isa
+    Inst: TEST72.inst52
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 52
+  - PseudoInst: TEST72.pinst53
+    ISA: TEST72.isa
+    Inst: TEST72.inst53
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 53
+  - PseudoInst: TEST72.pinst54
+    ISA: TEST72.isa
+    Inst: TEST72.inst54
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 54
+  - PseudoInst: TEST72.pinst55
+    ISA: TEST72.isa
+    Inst: TEST72.inst55
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 55
+  - PseudoInst: TEST72.pinst56
+    ISA: TEST72.isa
+    Inst: TEST72.inst56
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 56
+  - PseudoInst: TEST72.pinst57
+    ISA: TEST72.isa
+    Inst: TEST72.inst57
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 57
+  - PseudoInst: TEST72.pinst58
+    ISA: TEST72.isa
+    Inst: TEST72.inst58
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 58
+  - PseudoInst: TEST72.pinst59
+    ISA: TEST72.isa
+    Inst: TEST72.inst59
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 59
+  - PseudoInst: TEST72.pinst60
+    ISA: TEST72.isa
+    Inst: TEST72.inst60
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 60
+  - PseudoInst: TEST72.pinst61
+    ISA: TEST72.isa
+    Inst: TEST72.inst61
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 61
+  - PseudoInst: TEST72.pinst62
+    ISA: TEST72.isa
+    Inst: TEST72.inst62
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 62
+  - PseudoInst: TEST72.pinst63
+    ISA: TEST72.isa
+    Inst: TEST72.inst63
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 63
+  - PseudoInst: TEST72.pinst64
+    ISA: TEST72.isa
+    Inst: TEST72.inst64
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 64
+  - PseudoInst: TEST72.pinst65
+    ISA: TEST72.isa
+    Inst: TEST72.inst65
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 65
+  - PseudoInst: TEST72.pinst66
+    ISA: TEST72.isa
+    Inst: TEST72.inst66
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 66
+  - PseudoInst: TEST72.pinst67
+    ISA: TEST72.isa
+    Inst: TEST72.inst67
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 67
+  - PseudoInst: TEST72.pinst68
+    ISA: TEST72.isa
+    Inst: TEST72.inst68
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 68
+  - PseudoInst: TEST72.pinst69
+    ISA: TEST72.isa
+    Inst: TEST72.inst69
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 69
+  - PseudoInst: TEST72.pinst70
+    ISA: TEST72.isa
+    Inst: TEST72.inst70
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 70
+  - PseudoInst: TEST72.pinst71
+    ISA: TEST72.isa
+    Inst: TEST72.inst71
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 71
+Caches:
+  - Cache: TEST72.L2.cache
+    Sets: 2
+    Ways: 8
+  - Cache: TEST72.core0.L1.cache
+    Sets: 1
+    Ways: 1
+    SubLevel: TEST72.L2.cache
+  - Cache: TEST72.L2.cache
+    Sets: 2
+    Ways: 8
+  - Cache: TEST72.core1.L1.cache
+    Sets: 1
+    Ways: 1
+    SubLevel: TEST72.L2.cache
+  - Cache: TEST72.L2.cache
+    Sets: 2
+    Ways: 8
+  - Cache: TEST72.core2.L1.cache
+    Sets: 1
+    Ways: 1
+    SubLevel: TEST72.L2.cache
+  - Cache: TEST72.L2.cache
+    Sets: 2
+    Ways: 8
+  - Cache: TEST72.core3.L1.cache
+    Sets: 1
+    Ways: 1
+    SubLevel: TEST72.L2.cache
+  - Cache: TEST72.L2.cache
+    Sets: 2
+    Ways: 8
+Comms:
+  - Comm: TEST72.comm
+    Type: NOC
+    Width: 64
+    Endpoints:
+      - TEST72.core0
+      - TEST72.core1
+      - TEST72.core2
+      - TEST72.core3
+      - TEST72.L2.cache
+      - TEST72.vtp
+      - TEST72.0.mctrl
+      - TEST72.1.mctrl
+      - TEST72.2.mctrl
+      - TEST72.3.mctrl
+Scratchpads:
+  - Scratchpad: TEST72.0.spad
+    MemSize: 1024
+    RqstPorts: 1
+    RspPorts: 1
+    StartAddr: 34359739392
+  - Scratchpad: TEST72.1.spad
+    MemSize: 2048
+    RqstPorts: 1
+    RspPorts: 1
+    StartAddr: 34359740416
+  - Scratchpad: TEST72.2.spad
+    MemSize: 3072
+    RqstPorts: 1
+    RspPorts: 1
+    StartAddr: 34359741440
+  - Scratchpad: TEST72.3.spad
+    MemSize: 4096
+    RqstPorts: 1
+    RspPorts: 1
+    StartAddr: 34359742464
+MemoryControllers:
+  - MemoryController: TEST72.0.mctrl
+    Ports: 2
+  - MemoryController: TEST72.1.mctrl
+    Ports: 2
+  - MemoryController: TEST72.2.mctrl
+    Ports: 2
+  - MemoryController: TEST72.3.mctrl
+    Ports: 2
+VTPControllers:
+  - VTP: TEST72.vtp
+Extensions:
+  - Extension: TEST72.ext0
+    Type: unknown
+    Registers:
+      - RegName: TEST72.ext0.reg
+        Width: 64
+        Index: 0
+        IsFixedValue: false
+        IsSIMD: false
+        RWReg: false
+        ROReg: false
+        CSRReg: true
+        AMSReg: false
+        TUSReg: false
+        Shared: false
+    RegClasses:
+      - RegisterClassName: TEST72.ext0.regclass
+        Registers:
+          - TEST72.ext0.reg
+    ISAs:
+      - ISAName: TEST72.ext0.isa
+    RTLFile: TEST72.ext0.v
+  - Extension: TEST72.ext1
+    Type: unknown
+    Registers:
+      - RegName: TEST72.ext1.reg
+        Width: 64
+        Index: 0
+        IsFixedValue: false
+        IsSIMD: false
+        RWReg: false
+        ROReg: false
+        CSRReg: true
+        AMSReg: false
+        TUSReg: false
+        Shared: false
+    RegClasses:
+      - RegisterClassName: TEST72.ext1.regclass
+        Registers:
+          - TEST72.ext1.reg
+    ISAs:
+      - ISAName: TEST72.ext1.isa
+    RTLFile: TEST72.ext1.v
+  - Extension: TEST72.ext2
+    Type: unknown
+    Registers:
+      - RegName: TEST72.ext2.reg
+        Width: 64
+        Index: 0
+        IsFixedValue: false
+        IsSIMD: false
+        RWReg: false
+        ROReg: false
+        CSRReg: true
+        AMSReg: false
+        TUSReg: false
+        Shared: false
+    RegClasses:
+      - RegisterClassName: TEST72.ext2.regclass
+        Registers:
+          - TEST72.ext2.reg
+    ISAs:
+      - ISAName: TEST72.ext2.isa
+    RTLFile: TEST72.ext2.v
+  - Extension: TEST72.ext3
+    Type: unknown
+    Registers:
+      - RegName: TEST72.ext3.reg
+        Width: 64
+        Index: 0
+        IsFixedValue: false
+        IsSIMD: false
+        RWReg: false
+        ROReg: false
+        CSRReg: true
+        AMSReg: false
+        TUSReg: false
+        Shared: false
+    RegClasses:
+      - RegisterClassName: TEST72.ext3.regclass
+        Registers:
+          - TEST72.ext3.reg
+    ISAs:
+      - ISAName: TEST72.ext3.isa
+    RTLFile: TEST72.ext3.v
+Cores:
+  - Core: TEST72.core0
+    ThreadUnits: 1
+    Cache: TEST72.core0.L1.cache
+    ISA: TEST72.isa
+    RegisterClasses:
+      - RegClass: TEST72.regclass
+      - RegClass: TEST72.csrregclass
+    Extensions:
+      - Extension: TEST72.ext0
+  - Core: TEST72.core1
+    ThreadUnits: 2
+    Cache: TEST72.core1.L1.cache
+    ISA: TEST72.isa
+    RegisterClasses:
+      - RegClass: TEST72.regclass
+      - RegClass: TEST72.csrregclass
+    Extensions:
+      - Extension: TEST72.ext1
+  - Core: TEST72.core2
+    ThreadUnits: 3
+    Cache: TEST72.core2.L1.cache
+    ISA: TEST72.isa
+    RegisterClasses:
+      - RegClass: TEST72.regclass
+      - RegClass: TEST72.csrregclass
+    Extensions:
+      - Extension: TEST72.ext2
+  - Core: TEST72.core3
+    ThreadUnits: 4
+    Cache: TEST72.core3.L1.cache
+    ISA: TEST72.isa
+    RegisterClasses:
+      - RegClass: TEST72.regclass
+      - RegClass: TEST72.csrregclass
+    Extensions:
+      - Extension: TEST72.ext3
+Socs:
+  - Soc: TEST72.soc
+    Cores:
+      - Core: TEST72.core0
+      - Core: TEST72.core1
+      - Core: TEST72.core2
+      - Core: TEST72.core3

--- a/test/Yaml/Reader/MissingData/TEST39.yaml
+++ b/test/Yaml/Reader/MissingData/TEST39.yaml
@@ -1,0 +1,3137 @@
+ProjectInfo:
+  - ProjectName: TEST72
+    ProjectRoot: ./
+    ProjectType: unknown
+    ChiselMajorVersion: 3
+    ChiselMinorVersion: 0
+Registers:
+  - RegName: TEST72.0.reg
+    Width: 64
+    Index: 0
+    PseudoName: pseudoreg.0
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+    SubRegs:
+  - RegName: TEST72.1.reg
+    Width: 64
+    Index: 1
+    PseudoName: pseudoreg.1
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.2.reg
+    Width: 64
+    Index: 2
+    PseudoName: pseudoreg.2
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.3.reg
+    Width: 64
+    Index: 3
+    PseudoName: pseudoreg.3
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.4.reg
+    Width: 64
+    Index: 4
+    PseudoName: pseudoreg.4
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.5.reg
+    Width: 64
+    Index: 5
+    PseudoName: pseudoreg.5
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.6.reg
+    Width: 64
+    Index: 6
+    PseudoName: pseudoreg.6
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.7.reg
+    Width: 64
+    Index: 7
+    PseudoName: pseudoreg.7
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.8.reg
+    Width: 64
+    Index: 8
+    PseudoName: pseudoreg.8
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.9.reg
+    Width: 64
+    Index: 9
+    PseudoName: pseudoreg.9
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.10.reg
+    Width: 64
+    Index: 10
+    PseudoName: pseudoreg.10
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.11.reg
+    Width: 64
+    Index: 11
+    PseudoName: pseudoreg.11
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.12.reg
+    Width: 64
+    Index: 12
+    PseudoName: pseudoreg.12
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.13.reg
+    Width: 64
+    Index: 13
+    PseudoName: pseudoreg.13
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.14.reg
+    Width: 64
+    Index: 14
+    PseudoName: pseudoreg.14
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.15.reg
+    Width: 64
+    Index: 15
+    PseudoName: pseudoreg.15
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.16.reg
+    Width: 64
+    Index: 16
+    PseudoName: pseudoreg.16
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.17.reg
+    Width: 64
+    Index: 17
+    PseudoName: pseudoreg.17
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.18.reg
+    Width: 64
+    Index: 18
+    PseudoName: pseudoreg.18
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.19.reg
+    Width: 64
+    Index: 19
+    PseudoName: pseudoreg.19
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.20.reg
+    Width: 64
+    Index: 20
+    PseudoName: pseudoreg.20
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.21.reg
+    Width: 64
+    Index: 21
+    PseudoName: pseudoreg.21
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.22.reg
+    Width: 64
+    Index: 22
+    PseudoName: pseudoreg.22
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.23.reg
+    Width: 64
+    Index: 23
+    PseudoName: pseudoreg.23
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.24.reg
+    Width: 64
+    Index: 24
+    PseudoName: pseudoreg.24
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.25.reg
+    Width: 64
+    Index: 25
+    PseudoName: pseudoreg.25
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.26.reg
+    Width: 64
+    Index: 26
+    PseudoName: pseudoreg.26
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.27.reg
+    Width: 64
+    Index: 27
+    PseudoName: pseudoreg.27
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.28.reg
+    Width: 64
+    Index: 28
+    PseudoName: pseudoreg.28
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.29.reg
+    Width: 64
+    Index: 29
+    PseudoName: pseudoreg.29
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.30.reg
+    Width: 64
+    Index: 30
+    PseudoName: pseudoreg.30
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.31.reg
+    Width: 64
+    Index: 31
+    PseudoName: pseudoreg.31
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.32.reg
+    Width: 64
+    Index: 32
+    PseudoName: pseudoreg.32
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.33.reg
+    Width: 64
+    Index: 33
+    PseudoName: pseudoreg.33
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.34.reg
+    Width: 64
+    Index: 34
+    PseudoName: pseudoreg.34
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.35.reg
+    Width: 64
+    Index: 35
+    PseudoName: pseudoreg.35
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.36.reg
+    Width: 64
+    Index: 36
+    PseudoName: pseudoreg.36
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.37.reg
+    Width: 64
+    Index: 37
+    PseudoName: pseudoreg.37
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.38.reg
+    Width: 64
+    Index: 38
+    PseudoName: pseudoreg.38
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.39.reg
+    Width: 64
+    Index: 39
+    PseudoName: pseudoreg.39
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.40.reg
+    Width: 64
+    Index: 40
+    PseudoName: pseudoreg.40
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.41.reg
+    Width: 64
+    Index: 41
+    PseudoName: pseudoreg.41
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.42.reg
+    Width: 64
+    Index: 42
+    PseudoName: pseudoreg.42
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.43.reg
+    Width: 64
+    Index: 43
+    PseudoName: pseudoreg.43
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.44.reg
+    Width: 64
+    Index: 44
+    PseudoName: pseudoreg.44
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.45.reg
+    Width: 64
+    Index: 45
+    PseudoName: pseudoreg.45
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.46.reg
+    Width: 64
+    Index: 46
+    PseudoName: pseudoreg.46
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.47.reg
+    Width: 64
+    Index: 47
+    PseudoName: pseudoreg.47
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.48.reg
+    Width: 64
+    Index: 48
+    PseudoName: pseudoreg.48
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.49.reg
+    Width: 64
+    Index: 49
+    PseudoName: pseudoreg.49
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.50.reg
+    Width: 64
+    Index: 50
+    PseudoName: pseudoreg.50
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.51.reg
+    Width: 64
+    Index: 51
+    PseudoName: pseudoreg.51
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.52.reg
+    Width: 64
+    Index: 52
+    PseudoName: pseudoreg.52
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.53.reg
+    Width: 64
+    Index: 53
+    PseudoName: pseudoreg.53
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.54.reg
+    Width: 64
+    Index: 54
+    PseudoName: pseudoreg.54
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.55.reg
+    Width: 64
+    Index: 55
+    PseudoName: pseudoreg.55
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.56.reg
+    Width: 64
+    Index: 56
+    PseudoName: pseudoreg.56
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.57.reg
+    Width: 64
+    Index: 57
+    PseudoName: pseudoreg.57
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.58.reg
+    Width: 64
+    Index: 58
+    PseudoName: pseudoreg.58
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.59.reg
+    Width: 64
+    Index: 59
+    PseudoName: pseudoreg.59
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.60.reg
+    Width: 64
+    Index: 60
+    PseudoName: pseudoreg.60
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.61.reg
+    Width: 64
+    Index: 61
+    PseudoName: pseudoreg.61
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.62.reg
+    Width: 64
+    Index: 62
+    PseudoName: pseudoreg.62
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.63.reg
+    Width: 64
+    Index: 63
+    PseudoName: pseudoreg.63
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.64.reg
+    Width: 64
+    Index: 64
+    PseudoName: pseudoreg.64
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.65.reg
+    Width: 64
+    Index: 65
+    PseudoName: pseudoreg.65
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.66.reg
+    Width: 64
+    Index: 66
+    PseudoName: pseudoreg.66
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.67.reg
+    Width: 64
+    Index: 67
+    PseudoName: pseudoreg.67
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.68.reg
+    Width: 64
+    Index: 68
+    PseudoName: pseudoreg.68
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.69.reg
+    Width: 64
+    Index: 69
+    PseudoName: pseudoreg.69
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.70.reg
+    Width: 64
+    Index: 70
+    PseudoName: pseudoreg.70
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.71.reg
+    Width: 64
+    Index: 71
+    PseudoName: pseudoreg.71
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.0.csr
+    Width: 64
+    Index: 0
+    PseudoName: csr.0
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.1.csr
+    Width: 64
+    Index: 1
+    PseudoName: csr.1
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.2.csr
+    Width: 64
+    Index: 2
+    PseudoName: csr.2
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.3.csr
+    Width: 64
+    Index: 3
+    PseudoName: csr.3
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.4.csr
+    Width: 64
+    Index: 4
+    PseudoName: csr.4
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.5.csr
+    Width: 64
+    Index: 5
+    PseudoName: csr.5
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.6.csr
+    Width: 64
+    Index: 6
+    PseudoName: csr.6
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.7.csr
+    Width: 64
+    Index: 7
+    PseudoName: csr.7
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.8.csr
+    Width: 64
+    Index: 8
+    PseudoName: csr.8
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.9.csr
+    Width: 64
+    Index: 9
+    PseudoName: csr.9
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.10.csr
+    Width: 64
+    Index: 10
+    PseudoName: csr.10
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.11.csr
+    Width: 64
+    Index: 11
+    PseudoName: csr.11
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.12.csr
+    Width: 64
+    Index: 12
+    PseudoName: csr.12
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.13.csr
+    Width: 64
+    Index: 13
+    PseudoName: csr.13
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.14.csr
+    Width: 64
+    Index: 14
+    PseudoName: csr.14
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.15.csr
+    Width: 64
+    Index: 15
+    PseudoName: csr.15
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.16.csr
+    Width: 64
+    Index: 16
+    PseudoName: csr.16
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.17.csr
+    Width: 64
+    Index: 17
+    PseudoName: csr.17
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.18.csr
+    Width: 64
+    Index: 18
+    PseudoName: csr.18
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.19.csr
+    Width: 64
+    Index: 19
+    PseudoName: csr.19
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.20.csr
+    Width: 64
+    Index: 20
+    PseudoName: csr.20
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.21.csr
+    Width: 64
+    Index: 21
+    PseudoName: csr.21
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.22.csr
+    Width: 64
+    Index: 22
+    PseudoName: csr.22
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.23.csr
+    Width: 64
+    Index: 23
+    PseudoName: csr.23
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.24.csr
+    Width: 64
+    Index: 24
+    PseudoName: csr.24
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.25.csr
+    Width: 64
+    Index: 25
+    PseudoName: csr.25
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.26.csr
+    Width: 64
+    Index: 26
+    PseudoName: csr.26
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.27.csr
+    Width: 64
+    Index: 27
+    PseudoName: csr.27
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.28.csr
+    Width: 64
+    Index: 28
+    PseudoName: csr.28
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.29.csr
+    Width: 64
+    Index: 29
+    PseudoName: csr.29
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.30.csr
+    Width: 64
+    Index: 30
+    PseudoName: csr.30
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.31.csr
+    Width: 64
+    Index: 31
+    PseudoName: csr.31
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.32.csr
+    Width: 64
+    Index: 32
+    PseudoName: csr.32
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.33.csr
+    Width: 64
+    Index: 33
+    PseudoName: csr.33
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.34.csr
+    Width: 64
+    Index: 34
+    PseudoName: csr.34
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.35.csr
+    Width: 64
+    Index: 35
+    PseudoName: csr.35
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.36.csr
+    Width: 64
+    Index: 36
+    PseudoName: csr.36
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.37.csr
+    Width: 64
+    Index: 37
+    PseudoName: csr.37
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.38.csr
+    Width: 64
+    Index: 38
+    PseudoName: csr.38
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.39.csr
+    Width: 64
+    Index: 39
+    PseudoName: csr.39
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.40.csr
+    Width: 64
+    Index: 40
+    PseudoName: csr.40
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.41.csr
+    Width: 64
+    Index: 41
+    PseudoName: csr.41
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.42.csr
+    Width: 64
+    Index: 42
+    PseudoName: csr.42
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.43.csr
+    Width: 64
+    Index: 43
+    PseudoName: csr.43
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.44.csr
+    Width: 64
+    Index: 44
+    PseudoName: csr.44
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.45.csr
+    Width: 64
+    Index: 45
+    PseudoName: csr.45
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.46.csr
+    Width: 64
+    Index: 46
+    PseudoName: csr.46
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.47.csr
+    Width: 64
+    Index: 47
+    PseudoName: csr.47
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.48.csr
+    Width: 64
+    Index: 48
+    PseudoName: csr.48
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.49.csr
+    Width: 64
+    Index: 49
+    PseudoName: csr.49
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.50.csr
+    Width: 64
+    Index: 50
+    PseudoName: csr.50
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.51.csr
+    Width: 64
+    Index: 51
+    PseudoName: csr.51
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.52.csr
+    Width: 64
+    Index: 52
+    PseudoName: csr.52
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.53.csr
+    Width: 64
+    Index: 53
+    PseudoName: csr.53
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.54.csr
+    Width: 64
+    Index: 54
+    PseudoName: csr.54
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.55.csr
+    Width: 64
+    Index: 55
+    PseudoName: csr.55
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.56.csr
+    Width: 64
+    Index: 56
+    PseudoName: csr.56
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.57.csr
+    Width: 64
+    Index: 57
+    PseudoName: csr.57
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.58.csr
+    Width: 64
+    Index: 58
+    PseudoName: csr.58
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.59.csr
+    Width: 64
+    Index: 59
+    PseudoName: csr.59
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.60.csr
+    Width: 64
+    Index: 60
+    PseudoName: csr.60
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.61.csr
+    Width: 64
+    Index: 61
+    PseudoName: csr.61
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.62.csr
+    Width: 64
+    Index: 62
+    PseudoName: csr.62
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.63.csr
+    Width: 64
+    Index: 63
+    PseudoName: csr.63
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.64.csr
+    Width: 64
+    Index: 64
+    PseudoName: csr.64
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.65.csr
+    Width: 64
+    Index: 65
+    PseudoName: csr.65
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.66.csr
+    Width: 64
+    Index: 66
+    PseudoName: csr.66
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.67.csr
+    Width: 64
+    Index: 67
+    PseudoName: csr.67
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.68.csr
+    Width: 64
+    Index: 68
+    PseudoName: csr.68
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.69.csr
+    Width: 64
+    Index: 69
+    PseudoName: csr.69
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.70.csr
+    Width: 64
+    Index: 70
+    PseudoName: csr.70
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.71.csr
+    Width: 64
+    Index: 71
+    PseudoName: csr.71
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+RegClasses:
+  - RegisterClassName: TEST72.regclass
+    Registers:
+      - TEST72.0.reg
+      - TEST72.1.reg
+      - TEST72.2.reg
+      - TEST72.3.reg
+      - TEST72.4.reg
+      - TEST72.5.reg
+      - TEST72.6.reg
+      - TEST72.7.reg
+      - TEST72.8.reg
+      - TEST72.9.reg
+      - TEST72.10.reg
+      - TEST72.11.reg
+      - TEST72.12.reg
+      - TEST72.13.reg
+      - TEST72.14.reg
+      - TEST72.15.reg
+      - TEST72.16.reg
+      - TEST72.17.reg
+      - TEST72.18.reg
+      - TEST72.19.reg
+      - TEST72.20.reg
+      - TEST72.21.reg
+      - TEST72.22.reg
+      - TEST72.23.reg
+      - TEST72.24.reg
+      - TEST72.25.reg
+      - TEST72.26.reg
+      - TEST72.27.reg
+      - TEST72.28.reg
+      - TEST72.29.reg
+      - TEST72.30.reg
+      - TEST72.31.reg
+      - TEST72.32.reg
+      - TEST72.33.reg
+      - TEST72.34.reg
+      - TEST72.35.reg
+      - TEST72.36.reg
+      - TEST72.37.reg
+      - TEST72.38.reg
+      - TEST72.39.reg
+      - TEST72.40.reg
+      - TEST72.41.reg
+      - TEST72.42.reg
+      - TEST72.43.reg
+      - TEST72.44.reg
+      - TEST72.45.reg
+      - TEST72.46.reg
+      - TEST72.47.reg
+      - TEST72.48.reg
+      - TEST72.49.reg
+      - TEST72.50.reg
+      - TEST72.51.reg
+      - TEST72.52.reg
+      - TEST72.53.reg
+      - TEST72.54.reg
+      - TEST72.55.reg
+      - TEST72.56.reg
+      - TEST72.57.reg
+      - TEST72.58.reg
+      - TEST72.59.reg
+      - TEST72.60.reg
+      - TEST72.61.reg
+      - TEST72.62.reg
+      - TEST72.63.reg
+      - TEST72.64.reg
+      - TEST72.65.reg
+      - TEST72.66.reg
+      - TEST72.67.reg
+      - TEST72.68.reg
+      - TEST72.69.reg
+      - TEST72.70.reg
+      - TEST72.71.reg
+  - RegisterClassName: TEST72.csrregclass
+    Registers:
+      - TEST72.0.csr
+      - TEST72.1.csr
+      - TEST72.2.csr
+      - TEST72.3.csr
+      - TEST72.4.csr
+      - TEST72.5.csr
+      - TEST72.6.csr
+      - TEST72.7.csr
+      - TEST72.8.csr
+      - TEST72.9.csr
+      - TEST72.10.csr
+      - TEST72.11.csr
+      - TEST72.12.csr
+      - TEST72.13.csr
+      - TEST72.14.csr
+      - TEST72.15.csr
+      - TEST72.16.csr
+      - TEST72.17.csr
+      - TEST72.18.csr
+      - TEST72.19.csr
+      - TEST72.20.csr
+      - TEST72.21.csr
+      - TEST72.22.csr
+      - TEST72.23.csr
+      - TEST72.24.csr
+      - TEST72.25.csr
+      - TEST72.26.csr
+      - TEST72.27.csr
+      - TEST72.28.csr
+      - TEST72.29.csr
+      - TEST72.30.csr
+      - TEST72.31.csr
+      - TEST72.32.csr
+      - TEST72.33.csr
+      - TEST72.34.csr
+      - TEST72.35.csr
+      - TEST72.36.csr
+      - TEST72.37.csr
+      - TEST72.38.csr
+      - TEST72.39.csr
+      - TEST72.40.csr
+      - TEST72.41.csr
+      - TEST72.42.csr
+      - TEST72.43.csr
+      - TEST72.44.csr
+      - TEST72.45.csr
+      - TEST72.46.csr
+      - TEST72.47.csr
+      - TEST72.48.csr
+      - TEST72.49.csr
+      - TEST72.50.csr
+      - TEST72.51.csr
+      - TEST72.52.csr
+      - TEST72.53.csr
+      - TEST72.54.csr
+      - TEST72.55.csr
+      - TEST72.56.csr
+      - TEST72.57.csr
+      - TEST72.58.csr
+      - TEST72.59.csr
+      - TEST72.60.csr
+      - TEST72.61.csr
+      - TEST72.62.csr
+      - TEST72.63.csr
+      - TEST72.64.csr
+      - TEST72.65.csr
+      - TEST72.66.csr
+      - TEST72.67.csr
+      - TEST72.68.csr
+      - TEST72.69.csr
+      - TEST72.70.csr
+      - TEST72.71.csr
+ISAs:
+  - ISAName: TEST72.isa
+InstFormats:
+  - InstFormatName: TEST72.if
+    ISA: TEST72.isa
+    FormatWidth: 32
+    Fields:
+      - FieldName: opcode
+        FieldType: CGInstCode
+        FieldWidth: 8
+        StartBit: 0
+        EndBit: 7
+        MandatoryField: true
+      - FieldName: RB
+        FieldType: CGInstReg
+        FieldWidth: 8
+        StartBit: 8
+        EndBit: 15
+        MandatoryField: false
+        RegClass: TEST72.regclass
+      - FieldName: RA
+        FieldType: CGInstReg
+        FieldWidth: 8
+        StartBit: 16
+        EndBit: 23
+        MandatoryField: false
+        RegClass: TEST72.regclass
+      - FieldName: RT
+        FieldType: CGInstReg
+        FieldWidth: 8
+        StartBit: 24
+        EndBit: 31
+        MandatoryField: false
+        RegClass: TEST72.csrregclass
+Insts:
+  - Inst: TEST72.inst0
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 1
+  - Inst: TEST72.inst1
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 2
+  - Inst: TEST72.inst2
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 3
+  - Inst: TEST72.inst3
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 4
+  - Inst: TEST72.inst4
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 5
+  - Inst: TEST72.inst5
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 6
+  - Inst: TEST72.inst6
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 7
+  - Inst: TEST72.inst7
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 8
+  - Inst: TEST72.inst8
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 9
+  - Inst: TEST72.inst9
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 10
+  - Inst: TEST72.inst10
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 11
+  - Inst: TEST72.inst11
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 12
+  - Inst: TEST72.inst12
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 13
+  - Inst: TEST72.inst13
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 14
+  - Inst: TEST72.inst14
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 15
+  - Inst: TEST72.inst15
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 16
+  - Inst: TEST72.inst16
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 17
+  - Inst: TEST72.inst17
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 18
+  - Inst: TEST72.inst18
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 19
+  - Inst: TEST72.inst19
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 20
+  - Inst: TEST72.inst20
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 21
+  - Inst: TEST72.inst21
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 22
+  - Inst: TEST72.inst22
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 23
+  - Inst: TEST72.inst23
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 24
+  - Inst: TEST72.inst24
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 25
+  - Inst: TEST72.inst25
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 26
+  - Inst: TEST72.inst26
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 27
+  - Inst: TEST72.inst27
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 28
+  - Inst: TEST72.inst28
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 29
+  - Inst: TEST72.inst29
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 30
+  - Inst: TEST72.inst30
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 31
+  - Inst: TEST72.inst31
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 32
+  - Inst: TEST72.inst32
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 33
+  - Inst: TEST72.inst33
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 34
+  - Inst: TEST72.inst34
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 35
+  - Inst: TEST72.inst35
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 36
+  - Inst: TEST72.inst36
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 37
+  - Inst: TEST72.inst37
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 38
+  - Inst: TEST72.inst38
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 39
+  - Inst: TEST72.inst39
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 40
+  - Inst: TEST72.inst40
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 41
+  - Inst: TEST72.inst41
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 42
+  - Inst: TEST72.inst42
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 43
+  - Inst: TEST72.inst43
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 44
+  - Inst: TEST72.inst44
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 45
+  - Inst: TEST72.inst45
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 46
+  - Inst: TEST72.inst46
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 47
+  - Inst: TEST72.inst47
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 48
+  - Inst: TEST72.inst48
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 49
+  - Inst: TEST72.inst49
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 50
+  - Inst: TEST72.inst50
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 51
+  - Inst: TEST72.inst51
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 52
+  - Inst: TEST72.inst52
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 53
+  - Inst: TEST72.inst53
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 54
+  - Inst: TEST72.inst54
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 55
+  - Inst: TEST72.inst55
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 56
+  - Inst: TEST72.inst56
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 57
+  - Inst: TEST72.inst57
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 58
+  - Inst: TEST72.inst58
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 59
+  - Inst: TEST72.inst59
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 60
+  - Inst: TEST72.inst60
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 61
+  - Inst: TEST72.inst61
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 62
+  - Inst: TEST72.inst62
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 63
+  - Inst: TEST72.inst63
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 64
+  - Inst: TEST72.inst64
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 65
+  - Inst: TEST72.inst65
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 66
+  - Inst: TEST72.inst66
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 67
+  - Inst: TEST72.inst67
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 68
+  - Inst: TEST72.inst68
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 69
+  - Inst: TEST72.inst69
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 70
+  - Inst: TEST72.inst70
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 71
+  - Inst: TEST72.inst71
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 72
+PseudoInsts:
+  - PseudoInst: TEST72.pinst0
+    ISA: TEST72.isa
+    Inst: TEST72.inst0
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 0
+  - PseudoInst: TEST72.pinst1
+    ISA: TEST72.isa
+    Inst: TEST72.inst1
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 1
+  - PseudoInst: TEST72.pinst2
+    ISA: TEST72.isa
+    Inst: TEST72.inst2
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 2
+  - PseudoInst: TEST72.pinst3
+    ISA: TEST72.isa
+    Inst: TEST72.inst3
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 3
+  - PseudoInst: TEST72.pinst4
+    ISA: TEST72.isa
+    Inst: TEST72.inst4
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 4
+  - PseudoInst: TEST72.pinst5
+    ISA: TEST72.isa
+    Inst: TEST72.inst5
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 5
+  - PseudoInst: TEST72.pinst6
+    ISA: TEST72.isa
+    Inst: TEST72.inst6
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 6
+  - PseudoInst: TEST72.pinst7
+    ISA: TEST72.isa
+    Inst: TEST72.inst7
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 7
+  - PseudoInst: TEST72.pinst8
+    ISA: TEST72.isa
+    Inst: TEST72.inst8
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 8
+  - PseudoInst: TEST72.pinst9
+    ISA: TEST72.isa
+    Inst: TEST72.inst9
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 9
+  - PseudoInst: TEST72.pinst10
+    ISA: TEST72.isa
+    Inst: TEST72.inst10
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 10
+  - PseudoInst: TEST72.pinst11
+    ISA: TEST72.isa
+    Inst: TEST72.inst11
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 11
+  - PseudoInst: TEST72.pinst12
+    ISA: TEST72.isa
+    Inst: TEST72.inst12
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 12
+  - PseudoInst: TEST72.pinst13
+    ISA: TEST72.isa
+    Inst: TEST72.inst13
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 13
+  - PseudoInst: TEST72.pinst14
+    ISA: TEST72.isa
+    Inst: TEST72.inst14
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 14
+  - PseudoInst: TEST72.pinst15
+    ISA: TEST72.isa
+    Inst: TEST72.inst15
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 15
+  - PseudoInst: TEST72.pinst16
+    ISA: TEST72.isa
+    Inst: TEST72.inst16
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 16
+  - PseudoInst: TEST72.pinst17
+    ISA: TEST72.isa
+    Inst: TEST72.inst17
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 17
+  - PseudoInst: TEST72.pinst18
+    ISA: TEST72.isa
+    Inst: TEST72.inst18
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 18
+  - PseudoInst: TEST72.pinst19
+    ISA: TEST72.isa
+    Inst: TEST72.inst19
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 19
+  - PseudoInst: TEST72.pinst20
+    ISA: TEST72.isa
+    Inst: TEST72.inst20
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 20
+  - PseudoInst: TEST72.pinst21
+    ISA: TEST72.isa
+    Inst: TEST72.inst21
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 21
+  - PseudoInst: TEST72.pinst22
+    ISA: TEST72.isa
+    Inst: TEST72.inst22
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 22
+  - PseudoInst: TEST72.pinst23
+    ISA: TEST72.isa
+    Inst: TEST72.inst23
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 23
+  - PseudoInst: TEST72.pinst24
+    ISA: TEST72.isa
+    Inst: TEST72.inst24
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 24
+  - PseudoInst: TEST72.pinst25
+    ISA: TEST72.isa
+    Inst: TEST72.inst25
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 25
+  - PseudoInst: TEST72.pinst26
+    ISA: TEST72.isa
+    Inst: TEST72.inst26
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 26
+  - PseudoInst: TEST72.pinst27
+    ISA: TEST72.isa
+    Inst: TEST72.inst27
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 27
+  - PseudoInst: TEST72.pinst28
+    ISA: TEST72.isa
+    Inst: TEST72.inst28
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 28
+  - PseudoInst: TEST72.pinst29
+    ISA: TEST72.isa
+    Inst: TEST72.inst29
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 29
+  - PseudoInst: TEST72.pinst30
+    ISA: TEST72.isa
+    Inst: TEST72.inst30
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 30
+  - PseudoInst: TEST72.pinst31
+    ISA: TEST72.isa
+    Inst: TEST72.inst31
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 31
+  - PseudoInst: TEST72.pinst32
+    ISA: TEST72.isa
+    Inst: TEST72.inst32
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 32
+  - PseudoInst: TEST72.pinst33
+    ISA: TEST72.isa
+    Inst: TEST72.inst33
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 33
+  - PseudoInst: TEST72.pinst34
+    ISA: TEST72.isa
+    Inst: TEST72.inst34
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 34
+  - PseudoInst: TEST72.pinst35
+    ISA: TEST72.isa
+    Inst: TEST72.inst35
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 35
+  - PseudoInst: TEST72.pinst36
+    ISA: TEST72.isa
+    Inst: TEST72.inst36
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 36
+  - PseudoInst: TEST72.pinst37
+    ISA: TEST72.isa
+    Inst: TEST72.inst37
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 37
+  - PseudoInst: TEST72.pinst38
+    ISA: TEST72.isa
+    Inst: TEST72.inst38
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 38
+  - PseudoInst: TEST72.pinst39
+    ISA: TEST72.isa
+    Inst: TEST72.inst39
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 39
+  - PseudoInst: TEST72.pinst40
+    ISA: TEST72.isa
+    Inst: TEST72.inst40
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 40
+  - PseudoInst: TEST72.pinst41
+    ISA: TEST72.isa
+    Inst: TEST72.inst41
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 41
+  - PseudoInst: TEST72.pinst42
+    ISA: TEST72.isa
+    Inst: TEST72.inst42
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 42
+  - PseudoInst: TEST72.pinst43
+    ISA: TEST72.isa
+    Inst: TEST72.inst43
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 43
+  - PseudoInst: TEST72.pinst44
+    ISA: TEST72.isa
+    Inst: TEST72.inst44
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 44
+  - PseudoInst: TEST72.pinst45
+    ISA: TEST72.isa
+    Inst: TEST72.inst45
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 45
+  - PseudoInst: TEST72.pinst46
+    ISA: TEST72.isa
+    Inst: TEST72.inst46
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 46
+  - PseudoInst: TEST72.pinst47
+    ISA: TEST72.isa
+    Inst: TEST72.inst47
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 47
+  - PseudoInst: TEST72.pinst48
+    ISA: TEST72.isa
+    Inst: TEST72.inst48
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 48
+  - PseudoInst: TEST72.pinst49
+    ISA: TEST72.isa
+    Inst: TEST72.inst49
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 49
+  - PseudoInst: TEST72.pinst50
+    ISA: TEST72.isa
+    Inst: TEST72.inst50
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 50
+  - PseudoInst: TEST72.pinst51
+    ISA: TEST72.isa
+    Inst: TEST72.inst51
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 51
+  - PseudoInst: TEST72.pinst52
+    ISA: TEST72.isa
+    Inst: TEST72.inst52
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 52
+  - PseudoInst: TEST72.pinst53
+    ISA: TEST72.isa
+    Inst: TEST72.inst53
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 53
+  - PseudoInst: TEST72.pinst54
+    ISA: TEST72.isa
+    Inst: TEST72.inst54
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 54
+  - PseudoInst: TEST72.pinst55
+    ISA: TEST72.isa
+    Inst: TEST72.inst55
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 55
+  - PseudoInst: TEST72.pinst56
+    ISA: TEST72.isa
+    Inst: TEST72.inst56
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 56
+  - PseudoInst: TEST72.pinst57
+    ISA: TEST72.isa
+    Inst: TEST72.inst57
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 57
+  - PseudoInst: TEST72.pinst58
+    ISA: TEST72.isa
+    Inst: TEST72.inst58
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 58
+  - PseudoInst: TEST72.pinst59
+    ISA: TEST72.isa
+    Inst: TEST72.inst59
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 59
+  - PseudoInst: TEST72.pinst60
+    ISA: TEST72.isa
+    Inst: TEST72.inst60
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 60
+  - PseudoInst: TEST72.pinst61
+    ISA: TEST72.isa
+    Inst: TEST72.inst61
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 61
+  - PseudoInst: TEST72.pinst62
+    ISA: TEST72.isa
+    Inst: TEST72.inst62
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 62
+  - PseudoInst: TEST72.pinst63
+    ISA: TEST72.isa
+    Inst: TEST72.inst63
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 63
+  - PseudoInst: TEST72.pinst64
+    ISA: TEST72.isa
+    Inst: TEST72.inst64
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 64
+  - PseudoInst: TEST72.pinst65
+    ISA: TEST72.isa
+    Inst: TEST72.inst65
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 65
+  - PseudoInst: TEST72.pinst66
+    ISA: TEST72.isa
+    Inst: TEST72.inst66
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 66
+  - PseudoInst: TEST72.pinst67
+    ISA: TEST72.isa
+    Inst: TEST72.inst67
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 67
+  - PseudoInst: TEST72.pinst68
+    ISA: TEST72.isa
+    Inst: TEST72.inst68
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 68
+  - PseudoInst: TEST72.pinst69
+    ISA: TEST72.isa
+    Inst: TEST72.inst69
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 69
+  - PseudoInst: TEST72.pinst70
+    ISA: TEST72.isa
+    Inst: TEST72.inst70
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 70
+  - PseudoInst: TEST72.pinst71
+    ISA: TEST72.isa
+    Inst: TEST72.inst71
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 71
+Caches:
+  - Cache: TEST72.L2.cache
+    Sets: 2
+    Ways: 8
+  - Cache: TEST72.core0.L1.cache
+    Sets: 1
+    Ways: 1
+    SubLevel: TEST72.L2.cache
+  - Cache: TEST72.L2.cache
+    Sets: 2
+    Ways: 8
+  - Cache: TEST72.core1.L1.cache
+    Sets: 1
+    Ways: 1
+    SubLevel: TEST72.L2.cache
+  - Cache: TEST72.L2.cache
+    Sets: 2
+    Ways: 8
+  - Cache: TEST72.core2.L1.cache
+    Sets: 1
+    Ways: 1
+    SubLevel: TEST72.L2.cache
+  - Cache: TEST72.L2.cache
+    Sets: 2
+    Ways: 8
+  - Cache: TEST72.core3.L1.cache
+    Sets: 1
+    Ways: 1
+    SubLevel: TEST72.L2.cache
+  - Cache: TEST72.L2.cache
+    Sets: 2
+    Ways: 8
+Comms:
+  - Comm: TEST72.comm
+    Type: NOC
+    Width: 64
+    Endpoints:
+      - TEST72.core0
+      - TEST72.core1
+      - TEST72.core2
+      - TEST72.core3
+      - TEST72.L2.cache
+      - TEST72.vtp
+      - TEST72.0.mctrl
+      - TEST72.1.mctrl
+      - TEST72.2.mctrl
+      - TEST72.3.mctrl
+Scratchpads:
+  - Scratchpad: TEST72.0.spad
+    MemSize: 1024
+    RqstPorts: 1
+    RspPorts: 1
+    StartAddr: 34359739392
+  - Scratchpad: TEST72.1.spad
+    MemSize: 2048
+    RqstPorts: 1
+    RspPorts: 1
+    StartAddr: 34359740416
+  - Scratchpad: TEST72.2.spad
+    MemSize: 3072
+    RqstPorts: 1
+    RspPorts: 1
+    StartAddr: 34359741440
+  - Scratchpad: TEST72.3.spad
+    MemSize: 4096
+    RqstPorts: 1
+    RspPorts: 1
+    StartAddr: 34359742464
+MemoryControllers:
+  - MemoryController: TEST72.0.mctrl
+    Ports: 2
+  - MemoryController: TEST72.1.mctrl
+    Ports: 2
+  - MemoryController: TEST72.2.mctrl
+    Ports: 2
+  - MemoryController: TEST72.3.mctrl
+    Ports: 2
+VTPControllers:
+  - VTP: TEST72.vtp
+Extensions:
+  - Extension: TEST72.ext0
+    Type: unknown
+    Registers:
+      - RegName: TEST72.ext0.reg
+        Width: 64
+        Index: 0
+        IsFixedValue: false
+        IsSIMD: false
+        RWReg: false
+        ROReg: false
+        CSRReg: true
+        AMSReg: false
+        TUSReg: false
+        Shared: false
+    RegClasses:
+      - RegisterClassName: TEST72.ext0.regclass
+        Registers:
+          - TEST72.ext0.reg
+    ISAs:
+      - ISAName: TEST72.ext0.isa
+    RTLFile: TEST72.ext0.v
+  - Extension: TEST72.ext1
+    Type: unknown
+    Registers:
+      - RegName: TEST72.ext1.reg
+        Width: 64
+        Index: 0
+        IsFixedValue: false
+        IsSIMD: false
+        RWReg: false
+        ROReg: false
+        CSRReg: true
+        AMSReg: false
+        TUSReg: false
+        Shared: false
+    RegClasses:
+      - RegisterClassName: TEST72.ext1.regclass
+        Registers:
+          - TEST72.ext1.reg
+    ISAs:
+      - ISAName: TEST72.ext1.isa
+    RTLFile: TEST72.ext1.v
+  - Extension: TEST72.ext2
+    Type: unknown
+    Registers:
+      - RegName: TEST72.ext2.reg
+        Width: 64
+        Index: 0
+        IsFixedValue: false
+        IsSIMD: false
+        RWReg: false
+        ROReg: false
+        CSRReg: true
+        AMSReg: false
+        TUSReg: false
+        Shared: false
+    RegClasses:
+      - RegisterClassName: TEST72.ext2.regclass
+        Registers:
+          - TEST72.ext2.reg
+    ISAs:
+      - ISAName: TEST72.ext2.isa
+    RTLFile: TEST72.ext2.v
+  - Extension: TEST72.ext3
+    Type: unknown
+    Registers:
+      - RegName: TEST72.ext3.reg
+        Width: 64
+        Index: 0
+        IsFixedValue: false
+        IsSIMD: false
+        RWReg: false
+        ROReg: false
+        CSRReg: true
+        AMSReg: false
+        TUSReg: false
+        Shared: false
+    RegClasses:
+      - RegisterClassName: TEST72.ext3.regclass
+        Registers:
+          - TEST72.ext3.reg
+    ISAs:
+      - ISAName: TEST72.ext3.isa
+    RTLFile: TEST72.ext3.v
+Cores:
+  - Core: TEST72.core0
+    ThreadUnits: 1
+    Cache: TEST72.core0.L1.cache
+    ISA: TEST72.isa
+    RegisterClasses:
+      - RegClass: TEST72.regclass
+      - RegClass: TEST72.csrregclass
+    Extensions:
+      - Extension: TEST72.ext0
+  - Core: TEST72.core1
+    ThreadUnits: 2
+    Cache: TEST72.core1.L1.cache
+    ISA: TEST72.isa
+    RegisterClasses:
+      - RegClass: TEST72.regclass
+      - RegClass: TEST72.csrregclass
+    Extensions:
+      - Extension: TEST72.ext1
+  - Core: TEST72.core2
+    ThreadUnits: 3
+    Cache: TEST72.core2.L1.cache
+    ISA: TEST72.isa
+    RegisterClasses:
+      - RegClass: TEST72.regclass
+      - RegClass: TEST72.csrregclass
+    Extensions:
+      - Extension: TEST72.ext2
+  - Core: TEST72.core3
+    ThreadUnits: 4
+    Cache: TEST72.core3.L1.cache
+    ISA: TEST72.isa
+    RegisterClasses:
+      - RegClass: TEST72.regclass
+      - RegClass: TEST72.csrregclass
+    Extensions:
+      - Extension: TEST72.ext3
+Socs:
+  - Soc: TEST72.soc
+    Cores:
+      - Core: TEST72.core0
+      - Core: TEST72.core1
+      - Core: TEST72.core2
+      - Core: TEST72.core3

--- a/test/Yaml/Reader/MissingData/yaml_reader_missingdata_36.cpp
+++ b/test/Yaml/Reader/MissingData/yaml_reader_missingdata_36.cpp
@@ -1,0 +1,37 @@
+//
+// _YAML_READER_TEST36_CPP_
+//
+// Copyright (C) 2017-2018 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+// 
+//
+
+#include <iostream>
+#include "CoreGen/CoreGenBackend/CoreGenBackend.h"
+
+std::string PROJNAME = "TEST36";
+std::string PROJROOT = "./";
+std::string ARCHROOT = "./";
+std::string PROJYAML = "../TEST36.yaml";
+
+int main( int argc, char **argv ){
+  CoreGenBackend *CG = new CoreGenBackend(PROJNAME,
+                                          PROJROOT,
+                                          ARCHROOT);
+  if( !CG ){
+    std::cout << "ERROR : FAILED TO CREATE COREGEN OBJECT" << std::endl;
+    return -1;
+  }
+
+  if( !CG->ReadIR( PROJYAML ) ){
+    std::cout << "ERROR : FAILED TO READ YAML IR:" << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  delete CG;
+  return 0;
+}

--- a/test/Yaml/Reader/MissingData/yaml_reader_missingdata_37.cpp
+++ b/test/Yaml/Reader/MissingData/yaml_reader_missingdata_37.cpp
@@ -1,0 +1,37 @@
+//
+// _YAML_READER_TEST37_CPP_
+//
+// Copyright (C) 2017-2018 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+// 
+//
+
+#include <iostream>
+#include "CoreGen/CoreGenBackend/CoreGenBackend.h"
+
+std::string PROJNAME = "TEST37";
+std::string PROJROOT = "./";
+std::string ARCHROOT = "./";
+std::string PROJYAML = "../TEST37.yaml";
+
+int main( int argc, char **argv ){
+  CoreGenBackend *CG = new CoreGenBackend(PROJNAME,
+                                          PROJROOT,
+                                          ARCHROOT);
+  if( !CG ){
+    std::cout << "ERROR : FAILED TO CREATE COREGEN OBJECT" << std::endl;
+    return -1;
+  }
+
+  if( !CG->ReadIR( PROJYAML ) ){
+    std::cout << "ERROR : FAILED TO READ YAML IR:" << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  delete CG;
+  return 0;
+}

--- a/test/Yaml/Reader/MissingData/yaml_reader_missingdata_38.cpp
+++ b/test/Yaml/Reader/MissingData/yaml_reader_missingdata_38.cpp
@@ -1,0 +1,37 @@
+//
+// _YAML_READER_TEST38_CPP_
+//
+// Copyright (C) 2017-2018 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+// 
+//
+
+#include <iostream>
+#include "CoreGen/CoreGenBackend/CoreGenBackend.h"
+
+std::string PROJNAME = "TEST38";
+std::string PROJROOT = "./";
+std::string ARCHROOT = "./";
+std::string PROJYAML = "../TEST38.yaml";
+
+int main( int argc, char **argv ){
+  CoreGenBackend *CG = new CoreGenBackend(PROJNAME,
+                                          PROJROOT,
+                                          ARCHROOT);
+  if( !CG ){
+    std::cout << "ERROR : FAILED TO CREATE COREGEN OBJECT" << std::endl;
+    return -1;
+  }
+
+  if( !CG->ReadIR( PROJYAML ) ){
+    std::cout << "ERROR : FAILED TO READ YAML IR:" << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  delete CG;
+  return 0;
+}

--- a/test/Yaml/Reader/MissingData/yaml_reader_missingdata_39.cpp
+++ b/test/Yaml/Reader/MissingData/yaml_reader_missingdata_39.cpp
@@ -1,0 +1,37 @@
+//
+// _YAML_READER_TEST39_CPP_
+//
+// Copyright (C) 2017-2018 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+// 
+//
+
+#include <iostream>
+#include "CoreGen/CoreGenBackend/CoreGenBackend.h"
+
+std::string PROJNAME = "TEST39";
+std::string PROJROOT = "./";
+std::string ARCHROOT = "./";
+std::string PROJYAML = "../TEST39.yaml";
+
+int main( int argc, char **argv ){
+  CoreGenBackend *CG = new CoreGenBackend(PROJNAME,
+                                          PROJROOT,
+                                          ARCHROOT);
+  if( !CG ){
+    std::cout << "ERROR : FAILED TO CREATE COREGEN OBJECT" << std::endl;
+    return -1;
+  }
+
+  if( !CG->ReadIR( PROJYAML ) ){
+    std::cout << "ERROR : FAILED TO READ YAML IR:" << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  delete CG;
+  return 0;
+}

--- a/test/Yaml/Reader/TEST80.yaml
+++ b/test/Yaml/Reader/TEST80.yaml
@@ -1,0 +1,3143 @@
+ProjectInfo:
+  - ProjectName: TEST72
+    ProjectRoot: ./
+    ProjectType: unknown
+    ChiselMajorVersion: 3
+    ChiselMinorVersion: 0
+Registers:
+  - RegName: TEST72.0.reg
+    Width: 64
+    Index: 0
+    PseudoName: pseudoreg.0
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+    SubRegs:
+      - SubReg: SUBREG0
+        StartBit: 0
+        EndBit: 31
+      - SubReg: SUBREG1
+        StartBit: 32
+        EndBit: 63
+  - RegName: TEST72.1.reg
+    Width: 64
+    Index: 1
+    PseudoName: pseudoreg.1
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.2.reg
+    Width: 64
+    Index: 2
+    PseudoName: pseudoreg.2
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.3.reg
+    Width: 64
+    Index: 3
+    PseudoName: pseudoreg.3
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.4.reg
+    Width: 64
+    Index: 4
+    PseudoName: pseudoreg.4
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.5.reg
+    Width: 64
+    Index: 5
+    PseudoName: pseudoreg.5
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.6.reg
+    Width: 64
+    Index: 6
+    PseudoName: pseudoreg.6
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.7.reg
+    Width: 64
+    Index: 7
+    PseudoName: pseudoreg.7
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.8.reg
+    Width: 64
+    Index: 8
+    PseudoName: pseudoreg.8
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.9.reg
+    Width: 64
+    Index: 9
+    PseudoName: pseudoreg.9
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.10.reg
+    Width: 64
+    Index: 10
+    PseudoName: pseudoreg.10
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.11.reg
+    Width: 64
+    Index: 11
+    PseudoName: pseudoreg.11
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.12.reg
+    Width: 64
+    Index: 12
+    PseudoName: pseudoreg.12
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.13.reg
+    Width: 64
+    Index: 13
+    PseudoName: pseudoreg.13
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.14.reg
+    Width: 64
+    Index: 14
+    PseudoName: pseudoreg.14
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.15.reg
+    Width: 64
+    Index: 15
+    PseudoName: pseudoreg.15
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.16.reg
+    Width: 64
+    Index: 16
+    PseudoName: pseudoreg.16
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.17.reg
+    Width: 64
+    Index: 17
+    PseudoName: pseudoreg.17
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.18.reg
+    Width: 64
+    Index: 18
+    PseudoName: pseudoreg.18
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.19.reg
+    Width: 64
+    Index: 19
+    PseudoName: pseudoreg.19
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.20.reg
+    Width: 64
+    Index: 20
+    PseudoName: pseudoreg.20
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.21.reg
+    Width: 64
+    Index: 21
+    PseudoName: pseudoreg.21
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.22.reg
+    Width: 64
+    Index: 22
+    PseudoName: pseudoreg.22
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.23.reg
+    Width: 64
+    Index: 23
+    PseudoName: pseudoreg.23
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.24.reg
+    Width: 64
+    Index: 24
+    PseudoName: pseudoreg.24
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.25.reg
+    Width: 64
+    Index: 25
+    PseudoName: pseudoreg.25
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.26.reg
+    Width: 64
+    Index: 26
+    PseudoName: pseudoreg.26
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.27.reg
+    Width: 64
+    Index: 27
+    PseudoName: pseudoreg.27
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.28.reg
+    Width: 64
+    Index: 28
+    PseudoName: pseudoreg.28
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.29.reg
+    Width: 64
+    Index: 29
+    PseudoName: pseudoreg.29
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.30.reg
+    Width: 64
+    Index: 30
+    PseudoName: pseudoreg.30
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.31.reg
+    Width: 64
+    Index: 31
+    PseudoName: pseudoreg.31
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.32.reg
+    Width: 64
+    Index: 32
+    PseudoName: pseudoreg.32
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.33.reg
+    Width: 64
+    Index: 33
+    PseudoName: pseudoreg.33
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.34.reg
+    Width: 64
+    Index: 34
+    PseudoName: pseudoreg.34
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.35.reg
+    Width: 64
+    Index: 35
+    PseudoName: pseudoreg.35
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.36.reg
+    Width: 64
+    Index: 36
+    PseudoName: pseudoreg.36
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.37.reg
+    Width: 64
+    Index: 37
+    PseudoName: pseudoreg.37
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.38.reg
+    Width: 64
+    Index: 38
+    PseudoName: pseudoreg.38
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.39.reg
+    Width: 64
+    Index: 39
+    PseudoName: pseudoreg.39
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.40.reg
+    Width: 64
+    Index: 40
+    PseudoName: pseudoreg.40
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.41.reg
+    Width: 64
+    Index: 41
+    PseudoName: pseudoreg.41
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.42.reg
+    Width: 64
+    Index: 42
+    PseudoName: pseudoreg.42
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.43.reg
+    Width: 64
+    Index: 43
+    PseudoName: pseudoreg.43
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.44.reg
+    Width: 64
+    Index: 44
+    PseudoName: pseudoreg.44
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.45.reg
+    Width: 64
+    Index: 45
+    PseudoName: pseudoreg.45
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.46.reg
+    Width: 64
+    Index: 46
+    PseudoName: pseudoreg.46
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.47.reg
+    Width: 64
+    Index: 47
+    PseudoName: pseudoreg.47
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.48.reg
+    Width: 64
+    Index: 48
+    PseudoName: pseudoreg.48
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.49.reg
+    Width: 64
+    Index: 49
+    PseudoName: pseudoreg.49
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.50.reg
+    Width: 64
+    Index: 50
+    PseudoName: pseudoreg.50
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.51.reg
+    Width: 64
+    Index: 51
+    PseudoName: pseudoreg.51
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.52.reg
+    Width: 64
+    Index: 52
+    PseudoName: pseudoreg.52
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.53.reg
+    Width: 64
+    Index: 53
+    PseudoName: pseudoreg.53
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.54.reg
+    Width: 64
+    Index: 54
+    PseudoName: pseudoreg.54
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.55.reg
+    Width: 64
+    Index: 55
+    PseudoName: pseudoreg.55
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.56.reg
+    Width: 64
+    Index: 56
+    PseudoName: pseudoreg.56
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.57.reg
+    Width: 64
+    Index: 57
+    PseudoName: pseudoreg.57
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.58.reg
+    Width: 64
+    Index: 58
+    PseudoName: pseudoreg.58
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.59.reg
+    Width: 64
+    Index: 59
+    PseudoName: pseudoreg.59
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.60.reg
+    Width: 64
+    Index: 60
+    PseudoName: pseudoreg.60
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.61.reg
+    Width: 64
+    Index: 61
+    PseudoName: pseudoreg.61
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.62.reg
+    Width: 64
+    Index: 62
+    PseudoName: pseudoreg.62
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.63.reg
+    Width: 64
+    Index: 63
+    PseudoName: pseudoreg.63
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.64.reg
+    Width: 64
+    Index: 64
+    PseudoName: pseudoreg.64
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.65.reg
+    Width: 64
+    Index: 65
+    PseudoName: pseudoreg.65
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.66.reg
+    Width: 64
+    Index: 66
+    PseudoName: pseudoreg.66
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.67.reg
+    Width: 64
+    Index: 67
+    PseudoName: pseudoreg.67
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.68.reg
+    Width: 64
+    Index: 68
+    PseudoName: pseudoreg.68
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.69.reg
+    Width: 64
+    Index: 69
+    PseudoName: pseudoreg.69
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.70.reg
+    Width: 64
+    Index: 70
+    PseudoName: pseudoreg.70
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.71.reg
+    Width: 64
+    Index: 71
+    PseudoName: pseudoreg.71
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    Shared: false
+  - RegName: TEST72.0.csr
+    Width: 64
+    Index: 0
+    PseudoName: csr.0
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.1.csr
+    Width: 64
+    Index: 1
+    PseudoName: csr.1
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.2.csr
+    Width: 64
+    Index: 2
+    PseudoName: csr.2
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.3.csr
+    Width: 64
+    Index: 3
+    PseudoName: csr.3
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.4.csr
+    Width: 64
+    Index: 4
+    PseudoName: csr.4
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.5.csr
+    Width: 64
+    Index: 5
+    PseudoName: csr.5
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.6.csr
+    Width: 64
+    Index: 6
+    PseudoName: csr.6
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.7.csr
+    Width: 64
+    Index: 7
+    PseudoName: csr.7
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.8.csr
+    Width: 64
+    Index: 8
+    PseudoName: csr.8
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.9.csr
+    Width: 64
+    Index: 9
+    PseudoName: csr.9
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.10.csr
+    Width: 64
+    Index: 10
+    PseudoName: csr.10
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.11.csr
+    Width: 64
+    Index: 11
+    PseudoName: csr.11
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.12.csr
+    Width: 64
+    Index: 12
+    PseudoName: csr.12
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.13.csr
+    Width: 64
+    Index: 13
+    PseudoName: csr.13
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.14.csr
+    Width: 64
+    Index: 14
+    PseudoName: csr.14
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.15.csr
+    Width: 64
+    Index: 15
+    PseudoName: csr.15
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.16.csr
+    Width: 64
+    Index: 16
+    PseudoName: csr.16
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.17.csr
+    Width: 64
+    Index: 17
+    PseudoName: csr.17
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.18.csr
+    Width: 64
+    Index: 18
+    PseudoName: csr.18
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.19.csr
+    Width: 64
+    Index: 19
+    PseudoName: csr.19
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.20.csr
+    Width: 64
+    Index: 20
+    PseudoName: csr.20
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.21.csr
+    Width: 64
+    Index: 21
+    PseudoName: csr.21
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.22.csr
+    Width: 64
+    Index: 22
+    PseudoName: csr.22
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.23.csr
+    Width: 64
+    Index: 23
+    PseudoName: csr.23
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.24.csr
+    Width: 64
+    Index: 24
+    PseudoName: csr.24
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.25.csr
+    Width: 64
+    Index: 25
+    PseudoName: csr.25
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.26.csr
+    Width: 64
+    Index: 26
+    PseudoName: csr.26
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.27.csr
+    Width: 64
+    Index: 27
+    PseudoName: csr.27
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.28.csr
+    Width: 64
+    Index: 28
+    PseudoName: csr.28
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.29.csr
+    Width: 64
+    Index: 29
+    PseudoName: csr.29
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.30.csr
+    Width: 64
+    Index: 30
+    PseudoName: csr.30
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.31.csr
+    Width: 64
+    Index: 31
+    PseudoName: csr.31
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.32.csr
+    Width: 64
+    Index: 32
+    PseudoName: csr.32
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.33.csr
+    Width: 64
+    Index: 33
+    PseudoName: csr.33
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.34.csr
+    Width: 64
+    Index: 34
+    PseudoName: csr.34
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.35.csr
+    Width: 64
+    Index: 35
+    PseudoName: csr.35
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.36.csr
+    Width: 64
+    Index: 36
+    PseudoName: csr.36
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.37.csr
+    Width: 64
+    Index: 37
+    PseudoName: csr.37
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.38.csr
+    Width: 64
+    Index: 38
+    PseudoName: csr.38
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.39.csr
+    Width: 64
+    Index: 39
+    PseudoName: csr.39
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.40.csr
+    Width: 64
+    Index: 40
+    PseudoName: csr.40
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.41.csr
+    Width: 64
+    Index: 41
+    PseudoName: csr.41
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.42.csr
+    Width: 64
+    Index: 42
+    PseudoName: csr.42
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.43.csr
+    Width: 64
+    Index: 43
+    PseudoName: csr.43
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.44.csr
+    Width: 64
+    Index: 44
+    PseudoName: csr.44
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.45.csr
+    Width: 64
+    Index: 45
+    PseudoName: csr.45
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.46.csr
+    Width: 64
+    Index: 46
+    PseudoName: csr.46
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.47.csr
+    Width: 64
+    Index: 47
+    PseudoName: csr.47
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.48.csr
+    Width: 64
+    Index: 48
+    PseudoName: csr.48
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.49.csr
+    Width: 64
+    Index: 49
+    PseudoName: csr.49
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.50.csr
+    Width: 64
+    Index: 50
+    PseudoName: csr.50
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.51.csr
+    Width: 64
+    Index: 51
+    PseudoName: csr.51
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.52.csr
+    Width: 64
+    Index: 52
+    PseudoName: csr.52
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.53.csr
+    Width: 64
+    Index: 53
+    PseudoName: csr.53
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.54.csr
+    Width: 64
+    Index: 54
+    PseudoName: csr.54
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.55.csr
+    Width: 64
+    Index: 55
+    PseudoName: csr.55
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.56.csr
+    Width: 64
+    Index: 56
+    PseudoName: csr.56
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.57.csr
+    Width: 64
+    Index: 57
+    PseudoName: csr.57
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.58.csr
+    Width: 64
+    Index: 58
+    PseudoName: csr.58
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.59.csr
+    Width: 64
+    Index: 59
+    PseudoName: csr.59
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.60.csr
+    Width: 64
+    Index: 60
+    PseudoName: csr.60
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.61.csr
+    Width: 64
+    Index: 61
+    PseudoName: csr.61
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.62.csr
+    Width: 64
+    Index: 62
+    PseudoName: csr.62
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.63.csr
+    Width: 64
+    Index: 63
+    PseudoName: csr.63
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.64.csr
+    Width: 64
+    Index: 64
+    PseudoName: csr.64
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.65.csr
+    Width: 64
+    Index: 65
+    PseudoName: csr.65
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.66.csr
+    Width: 64
+    Index: 66
+    PseudoName: csr.66
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.67.csr
+    Width: 64
+    Index: 67
+    PseudoName: csr.67
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.68.csr
+    Width: 64
+    Index: 68
+    PseudoName: csr.68
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.69.csr
+    Width: 64
+    Index: 69
+    PseudoName: csr.69
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.70.csr
+    Width: 64
+    Index: 70
+    PseudoName: csr.70
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: TEST72.71.csr
+    Width: 64
+    Index: 71
+    PseudoName: csr.71
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+RegClasses:
+  - RegisterClassName: TEST72.regclass
+    Registers:
+      - TEST72.0.reg
+      - TEST72.1.reg
+      - TEST72.2.reg
+      - TEST72.3.reg
+      - TEST72.4.reg
+      - TEST72.5.reg
+      - TEST72.6.reg
+      - TEST72.7.reg
+      - TEST72.8.reg
+      - TEST72.9.reg
+      - TEST72.10.reg
+      - TEST72.11.reg
+      - TEST72.12.reg
+      - TEST72.13.reg
+      - TEST72.14.reg
+      - TEST72.15.reg
+      - TEST72.16.reg
+      - TEST72.17.reg
+      - TEST72.18.reg
+      - TEST72.19.reg
+      - TEST72.20.reg
+      - TEST72.21.reg
+      - TEST72.22.reg
+      - TEST72.23.reg
+      - TEST72.24.reg
+      - TEST72.25.reg
+      - TEST72.26.reg
+      - TEST72.27.reg
+      - TEST72.28.reg
+      - TEST72.29.reg
+      - TEST72.30.reg
+      - TEST72.31.reg
+      - TEST72.32.reg
+      - TEST72.33.reg
+      - TEST72.34.reg
+      - TEST72.35.reg
+      - TEST72.36.reg
+      - TEST72.37.reg
+      - TEST72.38.reg
+      - TEST72.39.reg
+      - TEST72.40.reg
+      - TEST72.41.reg
+      - TEST72.42.reg
+      - TEST72.43.reg
+      - TEST72.44.reg
+      - TEST72.45.reg
+      - TEST72.46.reg
+      - TEST72.47.reg
+      - TEST72.48.reg
+      - TEST72.49.reg
+      - TEST72.50.reg
+      - TEST72.51.reg
+      - TEST72.52.reg
+      - TEST72.53.reg
+      - TEST72.54.reg
+      - TEST72.55.reg
+      - TEST72.56.reg
+      - TEST72.57.reg
+      - TEST72.58.reg
+      - TEST72.59.reg
+      - TEST72.60.reg
+      - TEST72.61.reg
+      - TEST72.62.reg
+      - TEST72.63.reg
+      - TEST72.64.reg
+      - TEST72.65.reg
+      - TEST72.66.reg
+      - TEST72.67.reg
+      - TEST72.68.reg
+      - TEST72.69.reg
+      - TEST72.70.reg
+      - TEST72.71.reg
+  - RegisterClassName: TEST72.csrregclass
+    Registers:
+      - TEST72.0.csr
+      - TEST72.1.csr
+      - TEST72.2.csr
+      - TEST72.3.csr
+      - TEST72.4.csr
+      - TEST72.5.csr
+      - TEST72.6.csr
+      - TEST72.7.csr
+      - TEST72.8.csr
+      - TEST72.9.csr
+      - TEST72.10.csr
+      - TEST72.11.csr
+      - TEST72.12.csr
+      - TEST72.13.csr
+      - TEST72.14.csr
+      - TEST72.15.csr
+      - TEST72.16.csr
+      - TEST72.17.csr
+      - TEST72.18.csr
+      - TEST72.19.csr
+      - TEST72.20.csr
+      - TEST72.21.csr
+      - TEST72.22.csr
+      - TEST72.23.csr
+      - TEST72.24.csr
+      - TEST72.25.csr
+      - TEST72.26.csr
+      - TEST72.27.csr
+      - TEST72.28.csr
+      - TEST72.29.csr
+      - TEST72.30.csr
+      - TEST72.31.csr
+      - TEST72.32.csr
+      - TEST72.33.csr
+      - TEST72.34.csr
+      - TEST72.35.csr
+      - TEST72.36.csr
+      - TEST72.37.csr
+      - TEST72.38.csr
+      - TEST72.39.csr
+      - TEST72.40.csr
+      - TEST72.41.csr
+      - TEST72.42.csr
+      - TEST72.43.csr
+      - TEST72.44.csr
+      - TEST72.45.csr
+      - TEST72.46.csr
+      - TEST72.47.csr
+      - TEST72.48.csr
+      - TEST72.49.csr
+      - TEST72.50.csr
+      - TEST72.51.csr
+      - TEST72.52.csr
+      - TEST72.53.csr
+      - TEST72.54.csr
+      - TEST72.55.csr
+      - TEST72.56.csr
+      - TEST72.57.csr
+      - TEST72.58.csr
+      - TEST72.59.csr
+      - TEST72.60.csr
+      - TEST72.61.csr
+      - TEST72.62.csr
+      - TEST72.63.csr
+      - TEST72.64.csr
+      - TEST72.65.csr
+      - TEST72.66.csr
+      - TEST72.67.csr
+      - TEST72.68.csr
+      - TEST72.69.csr
+      - TEST72.70.csr
+      - TEST72.71.csr
+ISAs:
+  - ISAName: TEST72.isa
+InstFormats:
+  - InstFormatName: TEST72.if
+    ISA: TEST72.isa
+    FormatWidth: 32
+    Fields:
+      - FieldName: opcode
+        FieldType: CGInstCode
+        FieldWidth: 8
+        StartBit: 0
+        EndBit: 7
+        MandatoryField: true
+      - FieldName: RB
+        FieldType: CGInstReg
+        FieldWidth: 8
+        StartBit: 8
+        EndBit: 15
+        MandatoryField: false
+        RegClass: TEST72.regclass
+      - FieldName: RA
+        FieldType: CGInstReg
+        FieldWidth: 8
+        StartBit: 16
+        EndBit: 23
+        MandatoryField: false
+        RegClass: TEST72.regclass
+      - FieldName: RT
+        FieldType: CGInstReg
+        FieldWidth: 8
+        StartBit: 24
+        EndBit: 31
+        MandatoryField: false
+        RegClass: TEST72.csrregclass
+Insts:
+  - Inst: TEST72.inst0
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 1
+  - Inst: TEST72.inst1
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 2
+  - Inst: TEST72.inst2
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 3
+  - Inst: TEST72.inst3
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 4
+  - Inst: TEST72.inst4
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 5
+  - Inst: TEST72.inst5
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 6
+  - Inst: TEST72.inst6
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 7
+  - Inst: TEST72.inst7
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 8
+  - Inst: TEST72.inst8
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 9
+  - Inst: TEST72.inst9
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 10
+  - Inst: TEST72.inst10
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 11
+  - Inst: TEST72.inst11
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 12
+  - Inst: TEST72.inst12
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 13
+  - Inst: TEST72.inst13
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 14
+  - Inst: TEST72.inst14
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 15
+  - Inst: TEST72.inst15
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 16
+  - Inst: TEST72.inst16
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 17
+  - Inst: TEST72.inst17
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 18
+  - Inst: TEST72.inst18
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 19
+  - Inst: TEST72.inst19
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 20
+  - Inst: TEST72.inst20
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 21
+  - Inst: TEST72.inst21
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 22
+  - Inst: TEST72.inst22
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 23
+  - Inst: TEST72.inst23
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 24
+  - Inst: TEST72.inst24
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 25
+  - Inst: TEST72.inst25
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 26
+  - Inst: TEST72.inst26
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 27
+  - Inst: TEST72.inst27
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 28
+  - Inst: TEST72.inst28
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 29
+  - Inst: TEST72.inst29
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 30
+  - Inst: TEST72.inst30
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 31
+  - Inst: TEST72.inst31
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 32
+  - Inst: TEST72.inst32
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 33
+  - Inst: TEST72.inst33
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 34
+  - Inst: TEST72.inst34
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 35
+  - Inst: TEST72.inst35
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 36
+  - Inst: TEST72.inst36
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 37
+  - Inst: TEST72.inst37
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 38
+  - Inst: TEST72.inst38
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 39
+  - Inst: TEST72.inst39
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 40
+  - Inst: TEST72.inst40
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 41
+  - Inst: TEST72.inst41
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 42
+  - Inst: TEST72.inst42
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 43
+  - Inst: TEST72.inst43
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 44
+  - Inst: TEST72.inst44
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 45
+  - Inst: TEST72.inst45
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 46
+  - Inst: TEST72.inst46
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 47
+  - Inst: TEST72.inst47
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 48
+  - Inst: TEST72.inst48
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 49
+  - Inst: TEST72.inst49
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 50
+  - Inst: TEST72.inst50
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 51
+  - Inst: TEST72.inst51
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 52
+  - Inst: TEST72.inst52
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 53
+  - Inst: TEST72.inst53
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 54
+  - Inst: TEST72.inst54
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 55
+  - Inst: TEST72.inst55
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 56
+  - Inst: TEST72.inst56
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 57
+  - Inst: TEST72.inst57
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 58
+  - Inst: TEST72.inst58
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 59
+  - Inst: TEST72.inst59
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 60
+  - Inst: TEST72.inst60
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 61
+  - Inst: TEST72.inst61
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 62
+  - Inst: TEST72.inst62
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 63
+  - Inst: TEST72.inst63
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 64
+  - Inst: TEST72.inst64
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 65
+  - Inst: TEST72.inst65
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 66
+  - Inst: TEST72.inst66
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 67
+  - Inst: TEST72.inst67
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 68
+  - Inst: TEST72.inst68
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 69
+  - Inst: TEST72.inst69
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 70
+  - Inst: TEST72.inst70
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 71
+  - Inst: TEST72.inst71
+    ISA: TEST72.isa
+    InstFormat: TEST72.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 72
+PseudoInsts:
+  - PseudoInst: TEST72.pinst0
+    ISA: TEST72.isa
+    Inst: TEST72.inst0
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 0
+  - PseudoInst: TEST72.pinst1
+    ISA: TEST72.isa
+    Inst: TEST72.inst1
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 1
+  - PseudoInst: TEST72.pinst2
+    ISA: TEST72.isa
+    Inst: TEST72.inst2
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 2
+  - PseudoInst: TEST72.pinst3
+    ISA: TEST72.isa
+    Inst: TEST72.inst3
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 3
+  - PseudoInst: TEST72.pinst4
+    ISA: TEST72.isa
+    Inst: TEST72.inst4
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 4
+  - PseudoInst: TEST72.pinst5
+    ISA: TEST72.isa
+    Inst: TEST72.inst5
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 5
+  - PseudoInst: TEST72.pinst6
+    ISA: TEST72.isa
+    Inst: TEST72.inst6
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 6
+  - PseudoInst: TEST72.pinst7
+    ISA: TEST72.isa
+    Inst: TEST72.inst7
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 7
+  - PseudoInst: TEST72.pinst8
+    ISA: TEST72.isa
+    Inst: TEST72.inst8
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 8
+  - PseudoInst: TEST72.pinst9
+    ISA: TEST72.isa
+    Inst: TEST72.inst9
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 9
+  - PseudoInst: TEST72.pinst10
+    ISA: TEST72.isa
+    Inst: TEST72.inst10
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 10
+  - PseudoInst: TEST72.pinst11
+    ISA: TEST72.isa
+    Inst: TEST72.inst11
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 11
+  - PseudoInst: TEST72.pinst12
+    ISA: TEST72.isa
+    Inst: TEST72.inst12
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 12
+  - PseudoInst: TEST72.pinst13
+    ISA: TEST72.isa
+    Inst: TEST72.inst13
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 13
+  - PseudoInst: TEST72.pinst14
+    ISA: TEST72.isa
+    Inst: TEST72.inst14
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 14
+  - PseudoInst: TEST72.pinst15
+    ISA: TEST72.isa
+    Inst: TEST72.inst15
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 15
+  - PseudoInst: TEST72.pinst16
+    ISA: TEST72.isa
+    Inst: TEST72.inst16
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 16
+  - PseudoInst: TEST72.pinst17
+    ISA: TEST72.isa
+    Inst: TEST72.inst17
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 17
+  - PseudoInst: TEST72.pinst18
+    ISA: TEST72.isa
+    Inst: TEST72.inst18
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 18
+  - PseudoInst: TEST72.pinst19
+    ISA: TEST72.isa
+    Inst: TEST72.inst19
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 19
+  - PseudoInst: TEST72.pinst20
+    ISA: TEST72.isa
+    Inst: TEST72.inst20
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 20
+  - PseudoInst: TEST72.pinst21
+    ISA: TEST72.isa
+    Inst: TEST72.inst21
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 21
+  - PseudoInst: TEST72.pinst22
+    ISA: TEST72.isa
+    Inst: TEST72.inst22
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 22
+  - PseudoInst: TEST72.pinst23
+    ISA: TEST72.isa
+    Inst: TEST72.inst23
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 23
+  - PseudoInst: TEST72.pinst24
+    ISA: TEST72.isa
+    Inst: TEST72.inst24
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 24
+  - PseudoInst: TEST72.pinst25
+    ISA: TEST72.isa
+    Inst: TEST72.inst25
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 25
+  - PseudoInst: TEST72.pinst26
+    ISA: TEST72.isa
+    Inst: TEST72.inst26
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 26
+  - PseudoInst: TEST72.pinst27
+    ISA: TEST72.isa
+    Inst: TEST72.inst27
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 27
+  - PseudoInst: TEST72.pinst28
+    ISA: TEST72.isa
+    Inst: TEST72.inst28
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 28
+  - PseudoInst: TEST72.pinst29
+    ISA: TEST72.isa
+    Inst: TEST72.inst29
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 29
+  - PseudoInst: TEST72.pinst30
+    ISA: TEST72.isa
+    Inst: TEST72.inst30
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 30
+  - PseudoInst: TEST72.pinst31
+    ISA: TEST72.isa
+    Inst: TEST72.inst31
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 31
+  - PseudoInst: TEST72.pinst32
+    ISA: TEST72.isa
+    Inst: TEST72.inst32
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 32
+  - PseudoInst: TEST72.pinst33
+    ISA: TEST72.isa
+    Inst: TEST72.inst33
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 33
+  - PseudoInst: TEST72.pinst34
+    ISA: TEST72.isa
+    Inst: TEST72.inst34
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 34
+  - PseudoInst: TEST72.pinst35
+    ISA: TEST72.isa
+    Inst: TEST72.inst35
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 35
+  - PseudoInst: TEST72.pinst36
+    ISA: TEST72.isa
+    Inst: TEST72.inst36
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 36
+  - PseudoInst: TEST72.pinst37
+    ISA: TEST72.isa
+    Inst: TEST72.inst37
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 37
+  - PseudoInst: TEST72.pinst38
+    ISA: TEST72.isa
+    Inst: TEST72.inst38
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 38
+  - PseudoInst: TEST72.pinst39
+    ISA: TEST72.isa
+    Inst: TEST72.inst39
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 39
+  - PseudoInst: TEST72.pinst40
+    ISA: TEST72.isa
+    Inst: TEST72.inst40
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 40
+  - PseudoInst: TEST72.pinst41
+    ISA: TEST72.isa
+    Inst: TEST72.inst41
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 41
+  - PseudoInst: TEST72.pinst42
+    ISA: TEST72.isa
+    Inst: TEST72.inst42
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 42
+  - PseudoInst: TEST72.pinst43
+    ISA: TEST72.isa
+    Inst: TEST72.inst43
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 43
+  - PseudoInst: TEST72.pinst44
+    ISA: TEST72.isa
+    Inst: TEST72.inst44
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 44
+  - PseudoInst: TEST72.pinst45
+    ISA: TEST72.isa
+    Inst: TEST72.inst45
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 45
+  - PseudoInst: TEST72.pinst46
+    ISA: TEST72.isa
+    Inst: TEST72.inst46
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 46
+  - PseudoInst: TEST72.pinst47
+    ISA: TEST72.isa
+    Inst: TEST72.inst47
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 47
+  - PseudoInst: TEST72.pinst48
+    ISA: TEST72.isa
+    Inst: TEST72.inst48
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 48
+  - PseudoInst: TEST72.pinst49
+    ISA: TEST72.isa
+    Inst: TEST72.inst49
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 49
+  - PseudoInst: TEST72.pinst50
+    ISA: TEST72.isa
+    Inst: TEST72.inst50
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 50
+  - PseudoInst: TEST72.pinst51
+    ISA: TEST72.isa
+    Inst: TEST72.inst51
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 51
+  - PseudoInst: TEST72.pinst52
+    ISA: TEST72.isa
+    Inst: TEST72.inst52
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 52
+  - PseudoInst: TEST72.pinst53
+    ISA: TEST72.isa
+    Inst: TEST72.inst53
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 53
+  - PseudoInst: TEST72.pinst54
+    ISA: TEST72.isa
+    Inst: TEST72.inst54
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 54
+  - PseudoInst: TEST72.pinst55
+    ISA: TEST72.isa
+    Inst: TEST72.inst55
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 55
+  - PseudoInst: TEST72.pinst56
+    ISA: TEST72.isa
+    Inst: TEST72.inst56
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 56
+  - PseudoInst: TEST72.pinst57
+    ISA: TEST72.isa
+    Inst: TEST72.inst57
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 57
+  - PseudoInst: TEST72.pinst58
+    ISA: TEST72.isa
+    Inst: TEST72.inst58
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 58
+  - PseudoInst: TEST72.pinst59
+    ISA: TEST72.isa
+    Inst: TEST72.inst59
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 59
+  - PseudoInst: TEST72.pinst60
+    ISA: TEST72.isa
+    Inst: TEST72.inst60
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 60
+  - PseudoInst: TEST72.pinst61
+    ISA: TEST72.isa
+    Inst: TEST72.inst61
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 61
+  - PseudoInst: TEST72.pinst62
+    ISA: TEST72.isa
+    Inst: TEST72.inst62
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 62
+  - PseudoInst: TEST72.pinst63
+    ISA: TEST72.isa
+    Inst: TEST72.inst63
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 63
+  - PseudoInst: TEST72.pinst64
+    ISA: TEST72.isa
+    Inst: TEST72.inst64
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 64
+  - PseudoInst: TEST72.pinst65
+    ISA: TEST72.isa
+    Inst: TEST72.inst65
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 65
+  - PseudoInst: TEST72.pinst66
+    ISA: TEST72.isa
+    Inst: TEST72.inst66
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 66
+  - PseudoInst: TEST72.pinst67
+    ISA: TEST72.isa
+    Inst: TEST72.inst67
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 67
+  - PseudoInst: TEST72.pinst68
+    ISA: TEST72.isa
+    Inst: TEST72.inst68
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 68
+  - PseudoInst: TEST72.pinst69
+    ISA: TEST72.isa
+    Inst: TEST72.inst69
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 69
+  - PseudoInst: TEST72.pinst70
+    ISA: TEST72.isa
+    Inst: TEST72.inst70
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 70
+  - PseudoInst: TEST72.pinst71
+    ISA: TEST72.isa
+    Inst: TEST72.inst71
+    Encodings:
+      - EncodingField: RA
+        EncodingWidth: 8
+        EncodingValue: 71
+Caches:
+  - Cache: TEST72.L2.cache
+    Sets: 2
+    Ways: 8
+  - Cache: TEST72.core0.L1.cache
+    Sets: 1
+    Ways: 1
+    SubLevel: TEST72.L2.cache
+  - Cache: TEST72.L2.cache
+    Sets: 2
+    Ways: 8
+  - Cache: TEST72.core1.L1.cache
+    Sets: 1
+    Ways: 1
+    SubLevel: TEST72.L2.cache
+  - Cache: TEST72.L2.cache
+    Sets: 2
+    Ways: 8
+  - Cache: TEST72.core2.L1.cache
+    Sets: 1
+    Ways: 1
+    SubLevel: TEST72.L2.cache
+  - Cache: TEST72.L2.cache
+    Sets: 2
+    Ways: 8
+  - Cache: TEST72.core3.L1.cache
+    Sets: 1
+    Ways: 1
+    SubLevel: TEST72.L2.cache
+  - Cache: TEST72.L2.cache
+    Sets: 2
+    Ways: 8
+Comms:
+  - Comm: TEST72.comm
+    Type: NOC
+    Width: 64
+    Endpoints:
+      - TEST72.core0
+      - TEST72.core1
+      - TEST72.core2
+      - TEST72.core3
+      - TEST72.L2.cache
+      - TEST72.vtp
+      - TEST72.0.mctrl
+      - TEST72.1.mctrl
+      - TEST72.2.mctrl
+      - TEST72.3.mctrl
+Scratchpads:
+  - Scratchpad: TEST72.0.spad
+    MemSize: 1024
+    RqstPorts: 1
+    RspPorts: 1
+    StartAddr: 34359739392
+  - Scratchpad: TEST72.1.spad
+    MemSize: 2048
+    RqstPorts: 1
+    RspPorts: 1
+    StartAddr: 34359740416
+  - Scratchpad: TEST72.2.spad
+    MemSize: 3072
+    RqstPorts: 1
+    RspPorts: 1
+    StartAddr: 34359741440
+  - Scratchpad: TEST72.3.spad
+    MemSize: 4096
+    RqstPorts: 1
+    RspPorts: 1
+    StartAddr: 34359742464
+MemoryControllers:
+  - MemoryController: TEST72.0.mctrl
+    Ports: 2
+  - MemoryController: TEST72.1.mctrl
+    Ports: 2
+  - MemoryController: TEST72.2.mctrl
+    Ports: 2
+  - MemoryController: TEST72.3.mctrl
+    Ports: 2
+VTPControllers:
+  - VTP: TEST72.vtp
+Extensions:
+  - Extension: TEST72.ext0
+    Type: unknown
+    Registers:
+      - RegName: TEST72.ext0.reg
+        Width: 64
+        Index: 0
+        IsFixedValue: false
+        IsSIMD: false
+        RWReg: false
+        ROReg: false
+        CSRReg: true
+        AMSReg: false
+        TUSReg: false
+        Shared: false
+    RegClasses:
+      - RegisterClassName: TEST72.ext0.regclass
+        Registers:
+          - TEST72.ext0.reg
+    ISAs:
+      - ISAName: TEST72.ext0.isa
+    RTLFile: TEST72.ext0.v
+  - Extension: TEST72.ext1
+    Type: unknown
+    Registers:
+      - RegName: TEST72.ext1.reg
+        Width: 64
+        Index: 0
+        IsFixedValue: false
+        IsSIMD: false
+        RWReg: false
+        ROReg: false
+        CSRReg: true
+        AMSReg: false
+        TUSReg: false
+        Shared: false
+    RegClasses:
+      - RegisterClassName: TEST72.ext1.regclass
+        Registers:
+          - TEST72.ext1.reg
+    ISAs:
+      - ISAName: TEST72.ext1.isa
+    RTLFile: TEST72.ext1.v
+  - Extension: TEST72.ext2
+    Type: unknown
+    Registers:
+      - RegName: TEST72.ext2.reg
+        Width: 64
+        Index: 0
+        IsFixedValue: false
+        IsSIMD: false
+        RWReg: false
+        ROReg: false
+        CSRReg: true
+        AMSReg: false
+        TUSReg: false
+        Shared: false
+    RegClasses:
+      - RegisterClassName: TEST72.ext2.regclass
+        Registers:
+          - TEST72.ext2.reg
+    ISAs:
+      - ISAName: TEST72.ext2.isa
+    RTLFile: TEST72.ext2.v
+  - Extension: TEST72.ext3
+    Type: unknown
+    Registers:
+      - RegName: TEST72.ext3.reg
+        Width: 64
+        Index: 0
+        IsFixedValue: false
+        IsSIMD: false
+        RWReg: false
+        ROReg: false
+        CSRReg: true
+        AMSReg: false
+        TUSReg: false
+        Shared: false
+    RegClasses:
+      - RegisterClassName: TEST72.ext3.regclass
+        Registers:
+          - TEST72.ext3.reg
+    ISAs:
+      - ISAName: TEST72.ext3.isa
+    RTLFile: TEST72.ext3.v
+Cores:
+  - Core: TEST72.core0
+    ThreadUnits: 1
+    Cache: TEST72.core0.L1.cache
+    ISA: TEST72.isa
+    RegisterClasses:
+      - RegClass: TEST72.regclass
+      - RegClass: TEST72.csrregclass
+    Extensions:
+      - Extension: TEST72.ext0
+  - Core: TEST72.core1
+    ThreadUnits: 2
+    Cache: TEST72.core1.L1.cache
+    ISA: TEST72.isa
+    RegisterClasses:
+      - RegClass: TEST72.regclass
+      - RegClass: TEST72.csrregclass
+    Extensions:
+      - Extension: TEST72.ext1
+  - Core: TEST72.core2
+    ThreadUnits: 3
+    Cache: TEST72.core2.L1.cache
+    ISA: TEST72.isa
+    RegisterClasses:
+      - RegClass: TEST72.regclass
+      - RegClass: TEST72.csrregclass
+    Extensions:
+      - Extension: TEST72.ext2
+  - Core: TEST72.core3
+    ThreadUnits: 4
+    Cache: TEST72.core3.L1.cache
+    ISA: TEST72.isa
+    RegisterClasses:
+      - RegClass: TEST72.regclass
+      - RegClass: TEST72.csrregclass
+    Extensions:
+      - Extension: TEST72.ext3
+Socs:
+  - Soc: TEST72.soc
+    Cores:
+      - Core: TEST72.core0
+      - Core: TEST72.core1
+      - Core: TEST72.core2
+      - Core: TEST72.core3

--- a/test/Yaml/Reader/yaml_reader_test_80.cpp
+++ b/test/Yaml/Reader/yaml_reader_test_80.cpp
@@ -1,0 +1,37 @@
+//
+// _YAML_READER_TEST80_CPP_
+//
+// Copyright (C) 2017-2018 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+//
+
+#include <iostream>
+#include "CoreGen/CoreGenBackend/CoreGenBackend.h"
+
+std::string PROJNAME = "TEST80";
+std::string PROJROOT = "./";
+std::string ARCHROOT = "./";
+std::string PROJYAML = "../TEST80.yaml";
+
+int main( int argc, char **argv ){
+  CoreGenBackend *CG = new CoreGenBackend(PROJNAME,
+                                          PROJROOT,
+                                          ARCHROOT);
+  if( !CG ){
+    std::cout << "ERROR : FAILED TO CREATE COREGEN OBJECT" << std::endl;
+    return -1;
+  }
+
+  if( !CG->ReadIR( PROJYAML ) ){
+    std::cout << "ERROR : FAILED TO READ YAML IR:" << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  delete CG;
+  return 0;
+}

--- a/test/Yaml/Writer/yaml_test_72.cpp
+++ b/test/Yaml/Writer/yaml_test_72.cpp
@@ -1,0 +1,342 @@
+//
+// _YAML_TEST72_CPP_
+//
+// Copyright (C) 2017-2018 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+//
+
+#include <iostream>
+#include "CoreGen/CoreGenBackend/CoreGenBackend.h"
+
+std::string PROJNAME = "TEST72";
+std::string PROJROOT = "./";
+std::string ARCHROOT = "./";
+std::string PROJYAML = "TEST72.yaml";
+
+unsigned ITER=72;
+unsigned NUM_CORES=4;
+
+int main( int argc, char **argv ){
+  CoreGenBackend *CG = new CoreGenBackend(PROJNAME,
+                                          PROJROOT,
+                                          ARCHROOT);
+  if( !CG ){
+    std::cout << "ERROR : FAILED TO CREATE COREGEN OBJECT" << std::endl;
+    return -1;
+  }
+
+  // add an SoC
+  CoreGenSoC *SoC = CG->InsertSoC( PROJNAME + ".soc" );
+
+  // add a scratchpad
+  for( unsigned i=0; i<NUM_CORES; i++ ){
+    CoreGenSpad *Spad = CG->InsertSpad( PROJNAME + "." + std::to_string(i) + ".spad",
+                                        (i+1)*1024,
+                                        1,
+                                        1 );
+    Spad->SetStartAddr(0x800000000 + ((i+1)*1024));
+  }
+
+  // add a memory controller
+  std::vector<CoreGenMCtrl *> MCtrls;
+  for( unsigned i=0; i<NUM_CORES; i++ ){
+    MCtrls.push_back( CG->InsertMCtrl( PROJNAME + "." + std::to_string(i) + ".mctrl", 2 ) );
+  }
+
+  // add an ISA
+  CoreGenISA *ISA = CG->InsertISA( PROJNAME + ".isa" );
+
+  // add a core
+  std::vector<CoreGenCore *> Cores;
+  for( unsigned i=0; i<NUM_CORES; i++ ){
+    Cores.push_back( CG->InsertCore(PROJNAME + ".core" + std::to_string(i), ISA) );
+    Cores[i]->SetNumThreadUnits(i+1);
+  }
+
+  // add caches
+  std::vector<CoreGenCache *> L1;
+  for( unsigned i=0; i<NUM_CORES; i++ ){
+    CoreGenCache *Cache1 = CG->InsertCache( PROJNAME + ".core"
+                                            + std::to_string(i) + ".L1.cache", 1, 1 );
+    L1.push_back(Cache1);
+    if( !Cores[i]->InsertCache(Cache1) ){
+      std::cout << "ERROR : FAILED TO INSERT CACHE INTO CORE:" <<
+        CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+  }
+
+  // Shared L2
+  CoreGenCache *L2 = CG->InsertCache( PROJNAME + ".L2.cache", 2, 8 );
+  for( unsigned i=0; i<NUM_CORES; i++ ){
+    if( !L1[i]->SetChildCache( L2 ) ){
+      std::cout << "ERROR : FAILED TO SET CHILD CACHE LEVEL:" <<
+        CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+  }
+
+  // add a register class
+  CoreGenRegClass *RC = CG->InsertRegClass( PROJNAME + ".regclass" );
+  CoreGenRegClass *RCC = CG->InsertRegClass( PROJNAME + ".csrregclass" );
+
+  // insert the regclass into the cores
+  for( unsigned i=0; i<NUM_CORES; i++ ){
+    if( !Cores[i]->InsertRegClass( RC ) ){
+      std::cout << "ERROR : FAILED TO INSERT REGCLASS INTO CORE:" <<
+        CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+    if( !Cores[i]->InsertRegClass( RCC ) ){
+      std::cout << "ERROR : FAILED TO INSERT REGCLASS INTO CORE:" <<
+        CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+  }
+
+  // add a register
+  CoreGenReg *Reg[ITER];
+  for(unsigned i=0; i<ITER; i++ ){
+    Reg[i] = CG->InsertReg( PROJNAME + "." + std::to_string(i) + ".reg", i, 64 );
+    Reg[i]->SetPseudoName( "PSEUDOREG."+std::to_string(i) );
+    Reg[i]->SetAttrs(CoreGenReg::CGRegRW|CoreGenReg::CGRegTUS);
+
+    // insert the reg into the reg class
+    if( !RC->InsertReg( Reg[i] ) ){
+      std::cout << "ERROR : FAILED TO INSERT REG INTO REGCLASS:" <<
+        CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+  }
+
+  if( !Reg[0]->InsertSubReg("SUBREG0",0,31) ){
+    std::cout << "ERROR : FAILED TO INSERT SUBREG INTO REGISTER : " << Reg[0]->GetName()
+      <<  " : " << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+  if( !Reg[0]->InsertSubReg("SUBREG1",32,63) ){
+    std::cout << "ERROR : FAILED TO INSERT SUBREG INTO REGISTER : " << Reg[0]->GetName()
+      <<  " : " << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+
+  CoreGenReg *CSR[ITER];
+  for(unsigned i=0; i<ITER; i++ ){
+    CSR[i] = CG->InsertReg( PROJNAME + "." + std::to_string(i) + ".csr", i, 64 );
+    if( CSR[i] == nullptr ){
+      std::cout << "ERROR : FAILED TO CREATE NEW REGISTER:" << CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+    CSR[i]->SetPseudoName( "CSR."+std::to_string(i) );
+    CSR[i]->SetAttrs(CoreGenReg::CGRegCSR);
+
+    if( !RCC->InsertReg(CSR[i]) ){
+      std::cout << "ERROR : FAILED TO INSERT REG INTO REGCLASS:" <<
+        CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+  }
+
+  // insert the core in the SoC
+  for( unsigned i=0; i<NUM_CORES; i++ ){
+    if( !SoC->InsertCore( Cores[i] ) ){
+      std::cout << "ERROR : FAILED TO INSERT CORE INTO SOC:" <<
+        CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+  }
+
+  // create new instruction format
+  CoreGenInstFormat *IF = CG->InsertInstFormat( PROJNAME + ".if", ISA );
+
+  // insert some instruction fields
+  //  RT     RA     RB   OPC
+  // [31-24][23-16][15-8][7-0]
+  if( !IF->InsertField( "opcode", 0, 7, CoreGenInstFormat::CGInstCode, true ) ){
+    std::cout << "ERROR : FAILED TO INSERT opcode FIELD INTO FORMAT:" <<
+      CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+  if( !IF->InsertField( "RB", 8, 15, CoreGenInstFormat::CGInstReg, false ) ){
+    std::cout << "ERROR : FAILED TO INSERT rb FIELD INTO FORMAT:" <<
+      CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+  if( !IF->InsertField( "RA", 16, 23, CoreGenInstFormat::CGInstReg, false ) ){
+    std::cout << "ERROR : FAILED TO INSERT ra FIELD INTO FORMAT:" <<
+      CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+  if( !IF->InsertField( "RT", 24, 31, CoreGenInstFormat::CGInstReg, false ) ){
+    std::cout << "ERROR : FAILED TO INSERT rt FIELD INTO FORMAT:" <<
+      CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  if( !IF->InsertRegFieldMap("RB", RC) ){
+    std::cout << "ERROR : FAILED TO SET rb FIELD REGISTER CLASS:" <<
+      CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+  if( !IF->InsertRegFieldMap("RA", RC) ){
+    std::cout << "ERROR : FAILED TO SET ra FIELD REGISTER CLASS:" <<
+      CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+  if( !IF->InsertRegFieldMap("RT", RCC) ){
+    std::cout << "ERROR : FAILED TO SET rt FIELD REGISTER CLASS:" <<
+      CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  // create a new instruction
+  CoreGenInst *Inst[ITER];
+  CoreGenPseudoInst *PInst[ITER];
+  for( unsigned i=0; i<ITER; i++ ){
+    Inst[i] = CG->InsertInst( PROJNAME + ".inst" + std::to_string(i),
+                              ISA,
+                              IF );
+    PInst[i] = CG->InsertPseudoInst( PROJNAME + ".pinst" + std::to_string(i),
+                                     Inst[i] );
+
+    if( !Inst[i]->SetEncoding("opcode",i+1) ){
+      std::cout << "ERROR : FAILED TO SET opcode ENCODING FOR INSTRUCTION: " <<
+        Inst[i]->GetName() << " : " << CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+
+    if( !PInst[i]->SetEncoding("RA",i) ){
+      std::cout << "ERROR : FAILED TO SET ra ENCODING FOR PSEUDO INSTRUCTION: " <<
+        Inst[i]->GetName() << " : " << CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+  }
+
+  // insert a new Ext node
+  CoreGenExt *E[NUM_CORES];
+  for( unsigned i=0; i<NUM_CORES; i++ ){
+    E[i] = CG->InsertExt( PROJNAME + ".ext" + std::to_string(i) );
+    E[i]->SetRTLFile( E[i]->GetName() + ".v" );
+
+    CoreGenRegClass *ERC = E[i]->InsertRegClass( PROJNAME +
+                                              ".ext" + std::to_string(i) +
+                                              ".regclass" );
+    CoreGenISA *EISA = E[i]->InsertISA( PROJNAME + ".ext" + std::to_string(i) +
+                                     ".isa" );
+    CoreGenReg *EREG  = E[i]->InsertReg( PROJNAME + ".ext" + std::to_string(i) +
+                                      ".reg", 0, 64 );
+    if( !ERC->InsertReg(EREG ) ){
+      std::cout << "ERROR : FAILED TO INSERT EXT REGISTER INTO EXT REGISTER CLASS : "
+        << CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+  }
+
+  for( unsigned i=0; i<Cores.size(); i++ ){
+    if( !Cores[i]->InsertExt( E[i] ) ){
+      std::cout << "ERROR : FAILED TO INSERT EXTENSION FOR CORE " << i <<" : "
+        << CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+  }
+
+  // insert a new VTP node
+  CoreGenVTP *M = CG->InsertVTP( PROJNAME + ".vtp" );
+  if( !M ){
+    std::cout << "ERROR : FAILED TO INSERT NEW VIRTUAL TO PHYSICAL NODE "
+              << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  // insert a comm node
+  CoreGenComm *COMM = CG->InsertComm( PROJNAME + ".comm" );
+  if( !COMM ){
+    std::cout << "ERROR : FAILED TO INSERT NEW COMM NODE "
+              << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  if( !COMM->SetCommType(CGCommNoc) ){
+    std::cout << "ERROR : FAILED TO SET COMM NODE TYPE "
+              << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  if( !COMM->SetWidth(64) ){
+    std::cout << "ERROR : FAILED TO SET COMM NODE WIDTH "
+              << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  for( unsigned i=0; i<Cores.size(); i++ ){
+    if( !COMM->InsertEndpoint( static_cast<CoreGenNode *>(Cores[i]) ) ){
+      std::cout << "ERROR : FAILED TO INSERT COMM LINK FOR CORE " << i
+                << " : " << CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+  }
+
+  if( !COMM->InsertEndpoint( static_cast<CoreGenNode *>(L2) ) ){
+    std::cout << "ERROR : FAILED TO INSERT L2 CACHE INTO COMM LINK "
+              << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  if( !COMM->InsertEndpoint( static_cast<CoreGenNode *>(M) ) ){
+    std::cout << "ERROR : FAILED TO INSERT VTP LAYER INTO COMM LINK "
+              << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  for( unsigned i=0; i<MCtrls.size(); i++ ){
+    if( !COMM->InsertEndpoint( static_cast<CoreGenNode *>(MCtrls[i]) ) ){
+      std::cout << "ERROR : FAILED TO INSERT COMM LINK FOR MCTRL " << i
+                << " : " << CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+  }
+
+  // write the yaml
+  if( !CG->WriteIR( PROJYAML ) ){
+    std::cout << "ERROR : FAILED TO WRITE YAML IR:" << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  delete CG;
+  return 0;
+}


### PR DESCRIPTION
subregisters permit users to define named register aliases similar to pseudoregisters.  however, subregisters define specific bit ranges that the mnemonic is specifically aliased to.  this permits users to define larger registers and access individual bit ranges from instructions using these aliases names.