### PR TITLE
Changes to Exhibit PC register attribute in CoreGen and StoneCutter registers

### DIFF
--- a/include/CoreGen/CoreGenBackend/CoreGenReg.h
+++ b/include/CoreGen/CoreGenBackend/CoreGenReg.h
@@ -59,7 +59,8 @@ public:
     CGRegRW   = 0x02,     ///< CGRegAttr: Read-Write Register
     CGRegCSR  = 0x04,     ///< CGRegAttr: CSR
     CGRegAMS  = 0x08,     ///< CGRegAttr: Arithmetic Machine State
-    CGRegTUS  = 0x10      ///< CGRegAttr: Thread unit shared
+    CGRegTUS  = 0x10,     ///< CGRegAttr: Thread unit shared
+    CGRegPC   = 0x20      ///< CGRegAttr: PC register (one per reg file)
   }CGRegAttr;             ///< CoreGenReg: Register attributes
 
   /// Default Constructor
@@ -86,6 +87,9 @@ public:
 
   /// Is the register shared across thread units?
   bool IsTUSAttr();
+
+  /// Is the register a PC register?
+  bool IsPCAttr();
 
   /// Is the register file shared?
   bool IsShared() { return isShared; }

--- a/include/CoreGen/CoreGenBackend/Passes/Analysis/RegSafetyPass.h
+++ b/include/CoreGen/CoreGenBackend/Passes/Analysis/RegSafetyPass.h
@@ -42,11 +42,20 @@ private:
   /// Find overlapping SubReg names
   bool FindOverlappingSubRegNames(CoreGenReg *Reg);
 
-  /// Find overlappign SubReg bit fields
+  /// Find overlapping SubReg bit fields
   bool FindOverlappingSubRegFields(CoreGenReg *Reg);
 
   /// Test the SubReg values for various conditions
   bool TestSubRegs(CoreGenReg *Reg);
+
+  /// Tests the target register classes for existence of multiple PCs
+  bool TestPCRegs(CoreGenISA *ISA, std::vector<CoreGenRegClass *> RCs);
+
+  /// Test the target ISA for existence of a single PC
+  bool FindMultiplePC(CoreGenDAG *D, CoreGenISA *ISA);
+
+  /// Retrieve the register class fields from the target inst formats
+  std::vector<CoreGenRegClass *> GetRegClassFields( std::vector<CoreGenInstFormat *> IFs );
 
 public:
   /// Default constructor

--- a/include/CoreGen/StoneCutter/Passes/SCSigMap.h
+++ b/include/CoreGen/StoneCutter/Passes/SCSigMap.h
@@ -1,0 +1,47 @@
+//
+// _SCSigMap_h_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+/**
+ * \class SCSigMap
+ *
+ * \ingroup StoneCutter
+ *
+ * \brief StoneCutter CodeGen Pass: Generates a signal map for the target ISA
+ *
+ */
+
+#ifndef _STONECUTTER_SCPASS_SCSIGMAP_H_
+#define _STONECUTTER_SCPASS_SCSIGMAP_H_
+
+#include <map>
+#include <vector>
+#include "CoreGen/StoneCutter/SCPass.h"
+
+class SCSigMap : public SCPass {
+private:
+  std::string SigMap;         ///< Signal map output file
+
+public:
+  /// Default cosntructor
+  SCSigMap(Module *TM, SCOpts *O, SCMsg *M);
+
+  /// Default destructor
+  ~SCSigMap();
+
+  /// Execute the codegen
+  virtual bool Execute() override;
+
+  /// Sets the signal map file name
+  bool SetSignalMapFile(std::string SM);
+};
+
+#endif
+
+// EOF

--- a/include/CoreGen/StoneCutter/Passes/SCSigMap.h
+++ b/include/CoreGen/StoneCutter/Passes/SCSigMap.h
@@ -107,6 +107,9 @@ private:
     SCSig(SigType T, std::string I);
 
     /// Overloaded constructor
+    SCSig(SigType T, std::string I, std::string N);
+
+    /// Overloaded constructor
     SCSig(SigType T, unsigned W, std::string I, std::string N);
 
     /// Default destructor

--- a/include/CoreGen/StoneCutter/Passes/SCSigMap.h
+++ b/include/CoreGen/StoneCutter/Passes/SCSigMap.h
@@ -26,7 +26,151 @@
 
 class SCSigMap : public SCPass {
 private:
-  std::string SigMap;         ///< Signal map output file
+  typedef enum{
+    // Generic signals
+    SIGUNK    = 0,            ///< SigType: Unknown generic signal
+    SIGINSTF  = 1,            ///< SigType: Instruction field
+
+    // ALU signals
+    ALU_ADD   = 2,            ///< SigType: ALU Add
+    ALU_SUB   = 3,            ///< SigType: ALU Subtract
+    ALU_SLL   = 4,            ///< SigType: ALU Shift left logical
+    ALU_SRL   = 5,            ///< SigType: ALU Shift right logical
+    ALU_SRA   = 6,            ///< SigType: ALU Shift right arithmetic
+    ALU_AND   = 7,            ///< SigType: ALU Logical AND
+    ALU_OR    = 8,            ///< SigType: ALU Logical OR
+    ALU_XOR   = 9,            ///< SigType: ALU Logical XOR
+    ALU_SLT   = 10,           ///< SigType: ALU Set less than
+    ALU_SLTU  = 11,           ///< SigType: ALU Set less than unsigned
+    ALU_COPY  = 12,           ///< SigType: ALU Copy
+    ALU_MUL   = 13,           ///< SigType: ALU Multiplier
+    ALU_DIV   = 14,           ///< SigType: ALU Divide
+    ALU_REM   = 15,           ///< SigType: ALU Remainder
+
+    ALU_FADD  = 20,           ///< SigType: ALU Floating point add
+    ALU_FSUB  = 21,           ///< SigType: ALU Floating point subtract
+    ALU_FMUL  = 22,           ///< SigType: ALU Floating point multiply
+    ALU_FDIV  = 23,           ///< SigType: ALU Floating point divide
+    ALU_FREM  = 24,           ///< SigType: ALU Floating point remainder
+
+    // PC signals
+    PC_INCR   = 30,           ///< SigType: PC Increment
+    PC_BRJMP  = 31,           ///< SigType: PC Branch jump target
+    PC_JALR   = 32,           ///< SigType: PC Jump register target
+
+    // Branch signals
+    BR_N      = 40,           ///< SigType: Next
+    BR_NE     = 41,           ///< SigType: Branch not equal
+    BR_EQ     = 42,           ///< SigType: Branch equal
+    BR_GE     = 43,           ///< SigType: Branch greater than equal to signed
+    BR_GEU    = 44,           ///< SigType: Branch greater than equal to unsigned
+    BR_LT     = 45,           ///< SigType: Branch less than signed
+    BR_LTU    = 46,           ///< SigType: Branch less than unsigned
+    BR_J      = 47,           ///< SigType: Jump
+    BR_JR     = 48,           ///< SigType: Jump Register
+
+    // Register signals
+    REG_READ  = 49,           ///< SigType: Register read
+    REG_WRITE = 50,           ///< SigType: Register write
+
+    // Memory signals
+    MEM_READ  = 60,           ///< SigType: Memory read
+    MEM_WRITE = 61            ///< SigType: Memory write
+  }SigType;                   ///< SCSigMap: Emumerated types to represent signals
+
+  /**
+   * \class SCSig
+   *
+   * \ingroup StoneCutter
+   *
+   * \brief StoneCutter Signal: Individual signal instance
+   *
+   */
+  class SCSig{
+  private:
+    SigType Type;             ///< SCSig: Signal type
+    unsigned SigWidth;        ///< SCSig: Width of the target signal (in bits)
+    std::string Inst;         ///< SCSig: Name of the instruction
+    std::string Name;         ///< SCSig: Name of the signal
+
+  public:
+    /// Default constructor
+    SCSig(SigType T);
+
+    /// Overloaded constructor
+    SCSig(SigType T, unsigned W);
+
+    /// Overloaded constructor
+    SCSig(SigType T, unsigned W, std::string I);
+
+    /// Overload constructor
+    SCSig(SigType T, std::string I);
+
+    /// Overloaded constructor
+    SCSig(SigType T, unsigned W, std::string I, std::string N);
+
+    /// Default destructor
+    ~SCSig();
+
+    /// Sets the signal type
+    bool SetType( SigType Type );
+
+    /// Retrieves the signal type
+    SigType GetType() { return Type; }
+
+    /// Sets the width of the target signal
+    bool SetWidth( unsigned Width );
+
+    /// Retrieves the width of the target signal
+    unsigned GetWidth() { return SigWidth; }
+
+    /// Sets the signal name
+    bool SetName( std::string Name );
+
+    /// Retrieves the signal name
+    std::string GetName() { return Name; }
+
+    /// Set the instruction name for the signal
+    bool SetInst( std::string Inst );
+
+    /// Retrieves the instruction name for the signal
+    std::string GetInst() { return Inst; }
+  };
+
+  // Private variables
+  std::string SigMap;               ///< Signal map output file
+  std::vector<SCSig *> Signals;     ///< Signal vector
+
+  // Private functions
+  /// walks the LLVM Module object and discovers all the interior signals
+  bool DiscoverSigMap();
+
+  /// Writes the signal map out to a Yaml file
+  bool WriteSigMap();
+
+  /// Decodes an individual instruction for the signal map
+  bool CheckSigReq( Function &F, Instruction &I );
+
+  /// Returns true if the target signal is an ALU operation
+  bool isALUSig(SigType T);
+
+  /// Returns true if the target signal is a memory operation
+  bool isMemSig(SigType T);
+
+  /// Returns true if the target signal is a register operation
+  bool isRegSig(SigType T);
+
+  /// Returns true if the target signal is a branch signal
+  bool isBranchSig(SigType T);
+
+  /// Translates binary operations to signals
+  bool TranslateBinaryOp( Function &F, Instruction &I, SigType Type );
+
+  /// Translates logical operations to signals
+  bool TranslateLogicalOp( Function &F, Instruction &I, SigType Type );
+
+  /// Translates the I/O operands to signals
+  bool TranslateOperands( Function &F, Instruction &I );
 
 public:
   /// Default cosntructor

--- a/include/CoreGen/StoneCutter/SCChiselCodeGen.h
+++ b/include/CoreGen/StoneCutter/SCChiselCodeGen.h
@@ -72,6 +72,7 @@ private:
   SCOpts *Opts;                               ///< SC Options object
   SCMsg *Msgs;                                ///< SC Messages object
   std::string ChiselFile;                     ///< Output file
+  std::string SigMap;                         ///< Signal map output file
 
   std::ofstream OutFile;                      ///< Output file stream
 
@@ -84,6 +85,7 @@ private:
   void InitIntrinsics();                      ///< Init the intrinsics vector
   void InitPasses();                          ///< Init the pass vector
   bool ExecutePasses();                       ///< Executes all the code generation passes
+  bool ExecuteSignalMap();                    ///< Executes the signal map generator
 
 public:
 
@@ -96,6 +98,8 @@ public:
   /// Generate the LLVM Chisel output
   bool GenerateChisel();
 
+  /// Generate the signal map using the StoneCutter input
+  bool GenerateSignalMap(std::string);
 };
 
 #endif

--- a/include/CoreGen/StoneCutter/SCExec.h
+++ b/include/CoreGen/StoneCutter/SCExec.h
@@ -69,6 +69,7 @@ private:
   SCParser *Parser;   ///< SCExec: Parser object
 
   // private functions
+  /// SCExec: Print the list of passes
   bool PrintPassList();
 
 public:

--- a/include/CoreGen/StoneCutter/SCOpts.h
+++ b/include/CoreGen/StoneCutter/SCOpts.h
@@ -57,8 +57,10 @@ private:
   bool isDisable;   ///< SCOpts: Manually disabled passes flag
   bool isEnable;    ///< SCOpts: Manually disabled passes flag
   bool isListPass;  ///< SCOpts: User selected pass listing flag
+  bool isSigMap;    ///< SCOpts: Signal map selected
 
   std::string OutFile;  ///< SCOpts: Output file designator
+  std::string SigMap;   ///< SCOpts: Signal map output file
 
   std::vector<std::string> FileList;  ///< SCOpts: List of files to compile
 
@@ -121,6 +123,9 @@ public:
   /// SCOpts: Is verbosity enabled?
   bool IsVerbose() { return isVerbose; }
 
+  /// SCOpts: Is signal map enabled?
+  bool IsSignalMap() { return isSigMap; }
+
   /// SCOpts: Retrieve the list of disabled passes
   std::vector<std::string> GetDisabledPass() { return DisablePass; }
 
@@ -129,6 +134,9 @@ public:
 
   /// SCOpts: Retrieve the output file name
   std::string GetOutputFile() { return OutFile; }
+
+  /// SCOpts: Retrieve the signal map file name
+  std::string GetSignalMapFile() { return SigMap; }
 
   /// SCOpts: Get the number of input files
   unsigned GetNumInputFiles() { return FileList.size(); }
@@ -163,6 +171,9 @@ public:
   /// SCOpts: Sets the 'verbose' option
   bool SetVerbose() { isVerbose = true; return true; }
 
+  /// SCOpts: Sets the 'sigmap' option
+  bool SetSignalMap(std::string O) { isSigMap = true; SigMap = O; return true; }
+
   /// SCOpts: Disables the 'chisel' option
   bool UnsetChisel() { isChisel = false; return false; }
 
@@ -180,6 +191,9 @@ public:
 
   /// SCOpts: Disables the 'verbose' option
   bool UnsetVerbose() { isVerbose = false; return true; }
+
+  /// SCOpts: Disables the 'sigmap' option
+  bool UnsetSignalMap() { isSigMap = false; return true; }
 };
 
 #endif // _STONECUTTER_SCOPTS_H_

--- a/include/CoreGen/StoneCutter/SCParser.h
+++ b/include/CoreGen/StoneCutter/SCParser.h
@@ -304,6 +304,7 @@ public:
   ///               which captures the name and the associated registers
   class RegClassASTContainer {
     std::string Name;     ///< Name of the register class
+    std::string PC;       ///< Name of the PC register
     std::vector<std::string> Args;  ///< Register vector
     std::vector<VarAttrs> Attrs;    ///< Register attribute vector
     std::vector<std::tuple<std::string,std::string,VarAttrs>> SubRegs;  ///< Subregister vector
@@ -311,10 +312,11 @@ public:
   public:
     /// RegClassASTContainer default constructor
     RegClassASTContainer(const std::string &Name,
+                         const std::string &PC,
                          std::vector<std::string> Args,
                          std::vector<VarAttrs> Attrs,
                          std::vector<std::tuple<std::string,std::string,VarAttrs>> SubRegs)
-      : Name(Name), Args(std::move(Args)),
+      : Name(Name), PC(PC), Args(std::move(Args)),
         Attrs(std::move(Attrs)),SubRegs(std::move(SubRegs)) {}
 
     /// RegClassASTContainer: Retrieve the  name of the register class

--- a/include/CoreGen/StoneCutter/SCPass.h
+++ b/include/CoreGen/StoneCutter/SCPass.h
@@ -118,6 +118,9 @@ public:
   /// Retrieves the set of register classes for fields that match the instruction format
   std::vector<std::string> GetRegClassInstTypes(std::string InstFormat);
 
+  /// Traces the target operand back to its origin and returns the original name
+  std::string TraceOperand( Function &F, Use *U, bool &isPredef );
+
   /// Executes the target code generation pass
   virtual bool Execute() = 0;
 

--- a/include/CoreGen/StoneCutter/SCPass.h
+++ b/include/CoreGen/StoneCutter/SCPass.h
@@ -119,7 +119,8 @@ public:
   std::vector<std::string> GetRegClassInstTypes(std::string InstFormat);
 
   /// Traces the target operand back to its origin and returns the original name
-  std::string TraceOperand( Function &F, Use *U, bool &isPredef );
+  std::string TraceOperand( Function &F, Value *V,
+                            bool &isPredef, bool &isImm );
 
   /// Executes the target code generation pass
   virtual bool Execute() = 0;

--- a/include/CoreGen/StoneCutter/SCPass.h
+++ b/include/CoreGen/StoneCutter/SCPass.h
@@ -94,6 +94,9 @@ public:
   /// Retrieves the target attribute from the target global variable
   std::string GetGlobalAttribute(std::string Var, std::string Attribute);
 
+  /// Retrieves the register field register class global value for the target register and associated format
+  std::string GetGlobalRegClass(std::string Field, std::string Format);
+
   /// Retrieves the number of instruction formats that include the target variable
   unsigned GetNumInstFormats(std::string Var);
 

--- a/include/CoreGen/StoneCutter/SCUtil.h
+++ b/include/CoreGen/StoneCutter/SCUtil.h
@@ -66,7 +66,7 @@ const VarAttrEntry VarAttrEntryTable[] = {
   { "u8",      8, 1, false, false, false },
   { "u16",    16, 1, false, false, false },
   { "u32",    32, 1, false, false, false },
-  { "u64",    32, 1, false, false, false },
+  { "u64",    64, 1, false, false, false },
   { "s8",      8, 1, true,  false, false },
   { "s16",    16, 1, true,  false, false },
   { "s32",    32, 1, true,  false, false },

--- a/src/CoreGenBackend/CoreGenReg.cpp
+++ b/src/CoreGenBackend/CoreGenReg.cpp
@@ -40,6 +40,13 @@ bool CoreGenReg::SetPseudoName( std::string PseudoName ){
   return true;
 }
 
+bool CoreGenReg::IsPCAttr(){
+  if( (attrs & CoreGenReg::CGRegPC) > 0 ){
+    return true;
+  }
+  return false;
+}
+
 bool CoreGenReg::IsRWAttr(){
   if( (attrs & CoreGenReg::CGRegRW) > 0 ){
     return true;
@@ -102,6 +109,9 @@ bool CoreGenReg::UnsetAttrs( uint32_t Attr ){
     attrs &= ~(1 << CoreGenReg::CGRegCSR);
   }
   if( (Attr & CoreGenReg::CGRegTUS) > 0 ){
+    attrs &= ~(1 << CoreGenReg::CGRegTUS);
+  }
+  if( (Attr & CoreGenReg::CGRegPC) > 0 ){
     attrs &= ~(1 << CoreGenReg::CGRegTUS);
   }
   return true;

--- a/src/CoreGenBackend/CoreGenYaml.cpp
+++ b/src/CoreGenBackend/CoreGenYaml.cpp
@@ -783,12 +783,20 @@ void CoreGenYaml::WriteRegYaml(YAML::Emitter *out,
       *out << YAML:: Value << "false";
     }
 
+    *out << YAML::Key << "PCReg";
+    if( Regs[i]->IsPCAttr() ){
+      *out << YAML:: Value << "true";
+    }else{
+      *out << YAML:: Value << "false";
+    }
+
     *out << YAML::Key << "Shared";
     if( Regs[i]->IsShared() ){
       *out << YAML:: Value << "true";
     }else{
       *out << YAML:: Value << "false";
     }
+
 
     // write out the subregister encodings
     if( Regs[i]->GetNumSubRegs() > 0 ){
@@ -1559,6 +1567,7 @@ bool CoreGenYaml::ReadRegisterYaml(const YAML::Node& RegNodes,
     bool CSRReg = false;
     bool AMSReg = false;
     bool TUSReg = false;
+    bool PCReg = false;
     bool IsShared = false;
 
     ASP += "regIsSIMD(" + ASPName;
@@ -1569,6 +1578,7 @@ bool CoreGenYaml::ReadRegisterYaml(const YAML::Node& RegNodes,
     else{
       ASP += ", false).\n";
     }
+
     ASP += "regIsRWReg(" + ASPName;
     if( CheckValidNode(Node,"RWReg") ){
       RWReg = Node["RWReg"].as<bool>();
@@ -1577,6 +1587,7 @@ bool CoreGenYaml::ReadRegisterYaml(const YAML::Node& RegNodes,
     else{
       ASP += ", false).\n";
     }
+
     ASP += "regIsROReg(" + ASPName;
     if( CheckValidNode(Node,"ROReg") ){
       ROReg = Node["ROReg"].as<bool>();
@@ -1585,6 +1596,7 @@ bool CoreGenYaml::ReadRegisterYaml(const YAML::Node& RegNodes,
     else{
       ASP += ", false).\n";
     }
+
     ASP += "regIsCSRReg(" + ASPName;
     if( CheckValidNode(Node,"CSRReg") ){
       CSRReg = Node["CSRReg"].as<bool>();
@@ -1593,6 +1605,7 @@ bool CoreGenYaml::ReadRegisterYaml(const YAML::Node& RegNodes,
     else{
       ASP += ", false).\n";
     }
+
     ASP += "regIsAMSReg(" + ASPName;
     if( CheckValidNode(Node,"AMSReg") ){
       AMSReg = Node["AMSReg"].as<bool>();
@@ -1601,6 +1614,7 @@ bool CoreGenYaml::ReadRegisterYaml(const YAML::Node& RegNodes,
     else{
       ASP += ", false).\n";
     }
+
     ASP += "regIsTUSReg(" + ASPName;
     if( CheckValidNode(Node,"TUSReg") ){
       TUSReg = Node["TUSReg"].as<bool>();
@@ -1609,6 +1623,17 @@ bool CoreGenYaml::ReadRegisterYaml(const YAML::Node& RegNodes,
     else{
       ASP += ", false).\n";
     }
+
+    ASP += "regIsPCReg(" + ASPName;
+    if( CheckValidNode(Node,"PCReg") ){
+      TUSReg = Node["PCReg"].as<bool>();
+      ASP += ", true).\n";
+    }
+    else{
+      ASP += ", false).\n";
+    }
+
+
     if( CheckValidNode(Node,"Shared") ){
       IsShared = Node["Shared"].as<bool>();
     }
@@ -1655,6 +1680,9 @@ bool CoreGenYaml::ReadRegisterYaml(const YAML::Node& RegNodes,
     }
     if( TUSReg ){
       Attrs |= CoreGenReg::CGRegTUS;
+    }
+    if( PCReg ){
+      Attrs |= CoreGenReg::CGRegPC;
     }
     R->SetAttrs(Attrs);
     ASP += "regAttrs(" + ASPName + ", " + std::to_string(Attrs) + ").\n";

--- a/src/CoreGenBackend/CoreGenYaml.cpp
+++ b/src/CoreGenBackend/CoreGenYaml.cpp
@@ -1626,7 +1626,7 @@ bool CoreGenYaml::ReadRegisterYaml(const YAML::Node& RegNodes,
 
     ASP += "regIsPCReg(" + ASPName;
     if( CheckValidNode(Node,"PCReg") ){
-      TUSReg = Node["PCReg"].as<bool>();
+      PCReg = Node["PCReg"].as<bool>();
       ASP += ", true).\n";
     }
     else{

--- a/src/CoreGenBackend/Passes/Analysis/ASPSolverPass.cpp
+++ b/src/CoreGenBackend/Passes/Analysis/ASPSolverPass.cpp
@@ -91,7 +91,11 @@ bool ASPSolverPass::Execute(){
   char dot[] = ".";        // this is a temporary placeholder
   char *argv[] = {app,strdup(ASPDagFile.c_str()),dot,NULL};
   char *tmpname = strdup("/tmp/ASPTmpFileXXXXXX");
-  mkstemp(tmpname);
+  if( mkstemp(tmpname) == -1 ){
+    Errno->SetError( CGERR_ERROR, this->GetName() +
+                     " : Error generating temporary file" );
+    return false;
+  }
   std::ofstream of(tmpname);
   for( unsigned i=0; i < Files.size(); i++ ){
     std::ifstream infile( Files[i] );

--- a/src/CoreGenBackend/Passes/Data/SpecDoc.cpp
+++ b/src/CoreGenBackend/Passes/Data/SpecDoc.cpp
@@ -168,6 +168,13 @@ bool SpecDoc::WriteRegisterClassTex(CoreGenDAG *DAG, std::ofstream &ofs ){
           Attrs+="TUS";
           OrVal = true;
         }
+        if( REG->IsPCAttr() ){
+          if( OrVal ){
+            Attrs+=":";
+          }
+          Attrs+="PC";
+          OrVal = true;
+        }
         if( REG->IsShared() ){
           if( OrVal ){
             Attrs+=":";

--- a/src/StoneCutter/Passes/CMakeLists.txt
+++ b/src/StoneCutter/Passes/CMakeLists.txt
@@ -13,6 +13,7 @@ SCInstFormat.cpp
 SCIOWarn.cpp
 SCFieldIO.cpp
 SCPipeBuilder.cpp
+SCSigMap.cpp
 )
 
 set(llvm_codegens

--- a/src/StoneCutter/Passes/SCFieldIO.cpp
+++ b/src/StoneCutter/Passes/SCFieldIO.cpp
@@ -46,20 +46,15 @@ bool SCFieldIO::CheckInstArgs( Function &F, Instruction &I ){
   bool Rtn = true;
 
   if( I.getOpcode() == Instruction::Store ){
-    for( auto U : I.getOperand(1)->users() ){
-      if( auto Inst = dyn_cast<Instruction>(U) ){
-        for( unsigned i=0; i<Inst->getNumOperands(); i++ ){
-          // check to see if the i'th operand is in our field list
-          std::vector<std::string>::iterator it = std::find(Fields.begin(),
-                                                            Fields.end(),
-                                                            Inst->getOperand(i)->getName().str() );
-          if( it != Fields.end() ){
-            // print an error
-            this->PrintMsg( L_ERROR, "Cannot write to read-only field: " + *it );
-            Rtn = false;
-          }
-        }
-      }
+    Value *V1 = I.getOperand(1);
+    std::vector<std::string>::iterator it1 = std::find(Fields.begin(),
+                                                      Fields.end(),
+                                                      V1->getName().str() );
+    if( it1 != Fields.end() ){
+      this->PrintMsg( L_ERROR, "Cannot write to read-only field: " +
+                      V1->getName().str() +
+                      " in instruction " + F.getName().str());
+      Rtn = false;
     }
   }
 

--- a/src/StoneCutter/Passes/SCIOWarn.cpp
+++ b/src/StoneCutter/Passes/SCIOWarn.cpp
@@ -69,6 +69,23 @@ void SCIOWarn::CheckPrototypeIO( Function &F, Instruction &I ){
             return ;
         }
       }
+
+    }
+
+    // Argument does not appear in normal register classes,
+    // check the instruction format fields for a match
+    if( this->HasGlobalAttribute(ArgName,"field_name") ){
+      if( F.hasFnAttribute("instformat") ){
+        // function attribute exists
+        std::string InstFormat =
+          F.getFnAttribute("instformat").getValueAsString().str();
+        std::vector<std::string> Fields = GetInstFields(InstFormat);
+        for( unsigned i=0; i<Fields.size(); i++ ){
+          if( Fields[i] == ArgName ){
+            return ;
+          }
+        }
+      }
     }
 
     this->PrintMsg( L_WARN, "Detected rogue I/O operation to register file for variable=" +

--- a/src/StoneCutter/Passes/SCSigMap.cpp
+++ b/src/StoneCutter/Passes/SCSigMap.cpp
@@ -27,12 +27,365 @@ bool SCSigMap::SetSignalMapFile(std::string SM){
   return true;
 }
 
+bool SCSigMap::WriteSigMap(){
+  return true;
+}
+
+bool SCSigMap::TranslateLogicalOp( Function &F,
+                                   Instruction &I,
+                                   SigType Type ){
+  // initiate the binary signal
+  Signals.push_back(new SCSig(Type,F.getName().str()));
+
+  // interrogate the operands and write the operand enable signals
+  return true;
+}
+
+bool SCSigMap::TranslateBinaryOp( Function &F,
+                                  Instruction &I,
+                                  SigType Type ){
+  // initiate the binary signal
+  Signals.push_back(new SCSig(Type,F.getName().str()));
+
+  if( !TranslateOperands(F,I) )
+    return false;
+
+  return true;
+}
+
+bool SCSigMap::TranslateOperands( Function &F, Instruction &I ){
+
+  // walk all the instruction operands and trace the operands
+  // back to the origin; generate the necessary signals from there
+  for( auto Op = I.op_begin(); Op != I.op_end(); ++Op){
+    bool isPredef = false;
+    std::string OpName;
+    OpName = TraceOperand(F,Op,isPredef);
+  }
+
+
+  // interrogate the operands and write the operand enable signals
+  for( unsigned i=0; i<I.getNumOperands(); i++ ){
+    Value *Op = I.getOperand(i);
+    // check to see if this is a predefined register/register class/field
+    if( (HasGlobalAttribute(Op->getName().str(),"register")) ||
+        (HasGlobalAttribute(Op->getName().str(),"subregister")) ||
+        (HasGlobalAttribute(Op->getName().str(),"regclass")) ){
+    }else if( (HasGlobalAttribute(Op->getName().str(),"fieldtype")) ){
+      // part of an instruction format
+      // check to see whether this is an encoding field or an immediate
+    }else{
+      // top-level construct not found, must be a local operand
+    }
+  }
+  return true;
+}
+
+bool SCSigMap::CheckSigReq( Function &F, Instruction &I ){
+  // Decode each one of the relevant operations.
+  // The decoding map can be found in Instruction.def from
+  // https://llvm.org/svn/llvm-project/llvm/trunk/include/llvm/IR/Instruction.def
+  //
+  // For each one of the relevant signals decoded, generate a signal map
+  // and push it into the master vector of signals
+
+  // Decode everything else
+  switch( I.getOpcode() ){
+    // binary signals
+  case Instruction::Add :
+    if( !TranslateBinaryOp(F,I,ALU_ADD) )
+      return false;
+    break;
+  case Instruction::FAdd :
+    if( !TranslateBinaryOp(F,I,ALU_FADD) )
+      return false;
+    break;
+  case Instruction::Sub :
+    if( !TranslateBinaryOp(F,I,ALU_SUB) )
+      return false;
+    break;
+  case Instruction::FSub :
+    if( !TranslateBinaryOp(F,I,ALU_FSUB) )
+      return false;
+    break;
+  case Instruction::Mul :
+    if( !TranslateBinaryOp(F,I,ALU_MUL) )
+      return false;
+    break;
+  case Instruction::FMul :
+    if( !TranslateBinaryOp(F,I,ALU_FMUL) )
+      return false;
+    break;
+  case Instruction::UDiv :
+    if( !TranslateBinaryOp(F,I,ALU_DIV) )
+      return false;
+    break;
+  case Instruction::SDiv :
+    if( !TranslateBinaryOp(F,I,ALU_DIV) )
+      return false;
+    break;
+  case Instruction::FDiv :
+    if( !TranslateBinaryOp(F,I,ALU_FDIV) )
+      return false;
+    break;
+  case Instruction::URem :
+    if( !TranslateBinaryOp(F,I,ALU_REM) )
+      return false;
+    break;
+  case Instruction::SRem :
+    if( !TranslateBinaryOp(F,I,ALU_REM) )
+      return false;
+    break;
+  case Instruction::FRem :
+    if( !TranslateBinaryOp(F,I,ALU_FREM) )
+      return false;
+    break;
+    // logical signals
+  case Instruction::Shl :
+    if( !TranslateLogicalOp(F,I,ALU_SLL) )
+      return false;
+    break;
+  case Instruction::LShr :
+    if( !TranslateLogicalOp(F,I,ALU_SRL) )
+      return false;
+    break;
+  case Instruction::AShr :
+    if( !TranslateLogicalOp(F,I,ALU_SRA) )
+      return false;
+    break;
+  case Instruction::And :
+    if( !TranslateLogicalOp(F,I,ALU_AND) )
+      return false;
+    break;
+  case Instruction::Or :
+    if( !TranslateLogicalOp(F,I,ALU_OR) )
+      return false;
+    break;
+  case Instruction::Xor :
+    if( !TranslateLogicalOp(F,I,ALU_XOR) )
+      return false;
+    break;
+    // memory access signals
+  case Instruction::Alloca :
+    break;
+  case Instruction::Load :
+    break;
+  case Instruction::Store :
+    break;
+  case Instruction::GetElementPtr :
+    break;
+  case Instruction::Fence :
+    break;
+  case Instruction::AtomicCmpXchg :
+    break;
+  case Instruction::AtomicRMW :
+    break;
+    // cast signals
+  case Instruction::Trunc :
+    break;
+  case Instruction::ZExt :
+    break;
+  case Instruction::SExt :
+    break;
+  case Instruction::FPToUI :
+    break;
+  case Instruction::FPToSI :
+    break;
+  case Instruction::UIToFP :
+    break;
+  case Instruction::SIToFP :
+    break;
+  case Instruction::FPTrunc :
+    break;
+  case Instruction::FPExt :
+    break;
+  case Instruction::PtrToInt :
+    break;
+  case Instruction::IntToPtr :
+    break;
+  case Instruction::BitCast :
+    break;
+  case Instruction::AddrSpaceCast :
+    break;
+  case Instruction::CleanupPad :
+    break;
+  case Instruction::CatchPad :
+    break;
+    // other signals (cmp, etc)
+  case Instruction::ICmp :
+    break;
+  case Instruction::FCmp :
+    break;
+  case Instruction::Call :
+    break;
+  case Instruction::Select :
+    break;
+  case Instruction::ExtractElement :
+    break;
+  case Instruction::InsertElement :
+    break;
+  case Instruction::ShuffleVector :
+    break;
+  case Instruction::ExtractValue :
+    break;
+  case Instruction::InsertValue :
+    break;
+  case Instruction::Ret :
+  case Instruction::PHI :
+  case Instruction::UserOp1 :
+  case Instruction::UserOp2 :
+  case Instruction::VAArg :
+  case Instruction::LandingPad :
+    // ignore these instructions
+    return true;
+    break;
+  default:
+    return false;
+    break;
+  }
+  return true;
+}
+
+bool SCSigMap::DiscoverSigMap(){
+  bool Rtn = true;
+  // Walk all the functions
+  for( auto &Func : TheModule->getFunctionList() ){
+    // walk all the basic blocks
+    for( auto &BB : Func.getBasicBlockList() ){
+      // walk all the instructions
+      for( auto &Inst : BB.getInstList() ){
+        if( !CheckSigReq(Func,Inst) ){
+          Rtn = false;
+        }
+      }
+    }
+  }
+
+  return Rtn;
+}
+
+bool SCSigMap::isALUSig( SigType T ){
+  if( (T>SIGINSTF) && (T<PC_INCR) )
+    return true;
+  return false;
+}
+
+bool SCSigMap::isMemSig( SigType T ){
+  if( T>REG_WRITE )
+    return true;
+  return false;
+}
+
+bool SCSigMap::isRegSig( SigType T ){
+  if( (T>BR_JR) && (T<MEM_READ) )
+    return true;
+  return false;
+}
+
+bool SCSigMap::isBranchSig( SigType T ){
+  if( (T>PC_JALR) && (T<REG_READ) )
+    return true;
+  return false;
+}
+
 bool SCSigMap::Execute(){
   if( !TheModule ){
     this->PrintMsg( L_ERROR, "LLVM IR Module is null" );
     return false;
   }
 
+  // Stage 1: walk the module construct and discover any potential signals
+  if( !DiscoverSigMap() ){
+    return false;
+  }
+
+  // Stage 2: write the signal map out to a yaml file
+  if( !WriteSigMap() ){
+    return false;
+  }
+
+  return true;
+}
+
+SCSigMap::SCSig::SCSig(SigType T) : Type(T), SigWidth(0){
+}
+
+SCSigMap::SCSig::SCSig(SigType T,unsigned W) : Type(T), SigWidth(W){
+}
+
+SCSigMap::SCSig::SCSig(SigType T,std::string I) : Type(T), Inst(I){
+}
+
+SCSigMap::SCSig::SCSig(SigType T,unsigned W,std::string I)
+  : Type(T), SigWidth(W), Inst(I){
+}
+
+SCSigMap::SCSig::SCSig(SigType T,unsigned W,std::string I,std::string N)
+  : Type(T), SigWidth(W), Inst(I), Name(N){
+}
+
+SCSigMap::SCSig::~SCSig(){
+}
+
+bool SCSigMap::SCSig::SetType( SigType T ){
+  switch( T ){
+  case SIGUNK:
+  case SIGINSTF:
+  case ALU_ADD:
+  case ALU_SUB:
+  case ALU_SLL:
+  case ALU_SRL:
+  case ALU_SRA:
+  case ALU_AND:
+  case ALU_OR:
+  case ALU_XOR:
+  case ALU_SLT:
+  case ALU_SLTU:
+  case ALU_COPY:
+  case ALU_MUL:
+  case ALU_DIV:
+  case ALU_REM:
+  case ALU_FADD:
+  case ALU_FSUB:
+  case ALU_FMUL:
+  case ALU_FDIV:
+  case ALU_FREM:
+  case PC_INCR:
+  case PC_BRJMP:
+  case PC_JALR:
+  case BR_N:
+  case BR_NE:
+  case BR_EQ:
+  case BR_GE:
+  case BR_GEU:
+  case BR_LT:
+  case BR_LTU:
+  case BR_J:
+  case BR_JR:
+  case REG_READ:
+  case REG_WRITE:
+  case MEM_READ:
+  case MEM_WRITE:
+    Type = T;
+    return true;
+  default:
+    return false;
+  }
+  return true;
+}
+
+bool SCSigMap::SCSig::SetWidth( unsigned W ){
+  SigWidth = W;
+  return true;
+}
+
+bool SCSigMap::SCSig::SetName( std::string N ){
+  Name = N;
+  return true;
+}
+
+bool SCSigMap::SCSig::SetInst( std::string I ){
+  Inst = I;
   return true;
 }
 

--- a/src/StoneCutter/Passes/SCSigMap.cpp
+++ b/src/StoneCutter/Passes/SCSigMap.cpp
@@ -1,0 +1,39 @@
+//
+// _SCSigMap_cpp_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+
+#include "CoreGen/StoneCutter/Passes/SCSigMap.h"
+
+SCSigMap::SCSigMap(Module *TM,
+                           SCOpts *O,
+                           SCMsg *M)
+  : SCPass("SigMap",TM,O,M) {
+}
+
+SCSigMap::~SCSigMap(){
+}
+
+bool SCSigMap::SetSignalMapFile(std::string SM){
+  if( SM.length() == 0 ){
+    return false;
+  }
+  SigMap = SM;
+  return true;
+}
+
+bool SCSigMap::Execute(){
+  if( !TheModule ){
+    this->PrintMsg( L_ERROR, "LLVM IR Module is null" );
+    return false;
+  }
+
+  return true;
+}
+
+// EOF

--- a/src/StoneCutter/Passes/SCSigMap.cpp
+++ b/src/StoneCutter/Passes/SCSigMap.cpp
@@ -59,8 +59,9 @@ bool SCSigMap::TranslateOperands( Function &F, Instruction &I ){
   // back to the origin; generate the necessary signals from there
   for( auto Op = I.op_begin(); Op != I.op_end(); ++Op){
     bool isPredef = false;
+    bool isImm = false;
     std::string OpName;
-    OpName = TraceOperand(F,Op,isPredef);
+    OpName = TraceOperand(F,Op->get(),isPredef,isImm);
   }
 
 

--- a/src/StoneCutter/SCChiselCodeGen.cpp
+++ b/src/StoneCutter/SCChiselCodeGen.cpp
@@ -123,6 +123,35 @@ bool SCChiselCodeGen::ExecuteCodegen(){
   return true;
 }
 
+bool SCChiselCodeGen::ExecuteSignalMap(){
+  return true;
+}
+
+bool SCChiselCodeGen::GenerateSignalMap(std::string SM){
+  if( SM.length() == 0 ){
+    Msgs->PrintMsg( L_ERROR, "Signal map output full is null" );
+    return false;
+  }
+  SigMap = SM;
+
+  if( !Parser ){
+    Msgs->PrintMsg( L_ERROR, "No parsing input for generating signal map" );
+    return false;
+  }
+
+  if( !ExecutePasses() ){
+    Msgs->PrintMsg( L_ERROR, "Failed to execute passes for signal map" );
+    return false;
+  }
+
+  if( !ExecuteSignalMap() ){
+    Msgs->PrintMsg( L_ERROR, "Failed to generate signal map" );
+    return false;
+  }
+
+  return true;
+}
+
 bool SCChiselCodeGen::GenerateChisel(){
 
   if( !Parser ){

--- a/src/StoneCutter/SCChiselCodeGen.cpp
+++ b/src/StoneCutter/SCChiselCodeGen.cpp
@@ -64,12 +64,10 @@ void SCChiselCodeGen::InitPasses(){
   Passes.push_back(static_cast<SCPass *>(new SCPipeBuilder(SCParser::TheModule.get(),
                                                        Opts,
                                                        Msgs)));
-#if 0
   // temporarily disabling pass
   Passes.push_back(static_cast<SCPass *>(new SCIOWarn(SCParser::TheModule.get(),
                                                       Opts,
                                                       Msgs)));
-#endif
   Passes.push_back(static_cast<SCPass *>(new SCFieldIO(SCParser::TheModule.get(),
                                                        Opts,
                                                        Msgs)));

--- a/src/StoneCutter/SCChiselCodeGen.cpp
+++ b/src/StoneCutter/SCChiselCodeGen.cpp
@@ -64,9 +64,12 @@ void SCChiselCodeGen::InitPasses(){
   Passes.push_back(static_cast<SCPass *>(new SCPipeBuilder(SCParser::TheModule.get(),
                                                        Opts,
                                                        Msgs)));
+#if 0
+  // temporarily disabling pass
   Passes.push_back(static_cast<SCPass *>(new SCIOWarn(SCParser::TheModule.get(),
                                                       Opts,
                                                       Msgs)));
+#endif
   Passes.push_back(static_cast<SCPass *>(new SCFieldIO(SCParser::TheModule.get(),
                                                        Opts,
                                                        Msgs)));

--- a/src/StoneCutter/SCOpts.cpp
+++ b/src/StoneCutter/SCOpts.cpp
@@ -15,7 +15,7 @@ SCOpts::SCOpts(SCMsg *M, int A, char **C)
   : argc(A), argv(C),
   isKeep(false), isParse(true), isIR(true),
   isOptimize(true), isChisel(true), isCG(false), isVerbose(false),
-  isDisable(false), isEnable(false), isListPass(false),
+  isDisable(false), isEnable(false), isListPass(false), isSigMap(false),
   Msgs(M) {}
 
 // ------------------------------------------------- DESTRUCTOR
@@ -90,6 +90,14 @@ bool SCOpts::ParseOpts(bool *isHelp){
       }
       std::string F(argv[i+1]);
       OutFile = F;
+      i++;
+    }else if( (s=="-s") || (s=="-sigmap") || (s=="--sigmap") ){
+      if( i+1 > (argc-1) ){
+        Msgs->PrintMsg(L_ERROR, "--sigmap requires an argument");
+        return false;
+      }
+      std::string F(argv[i+1]);
+      SigMap = F;
       i++;
     }else if( (s=="-k") || (s=="-keep") || (s=="--keep") ){
       isKeep = true;
@@ -182,6 +190,7 @@ void SCOpts::PrintHelp(){
   Msgs->PrintRawMsg("     -c|-chisel|--chisel                 : Generate Chisel output (default=on");
   Msgs->PrintRawMsg("     -p|-parse|--parse                   : Parse but do not compile");
   Msgs->PrintRawMsg("     -f|-outfile|--outfile /path/to/out  : Set the output file name");
+  Msgs->PrintRawMsg("     -s|-sigmap|--sigmap /path/to/sigmap : Generates a signal map");
   Msgs->PrintRawMsg("     -o|-object|--object                 : Generate target object file [*.o]");
   Msgs->PrintRawMsg("     -V|-version|--version               : Print the version info");
   Msgs->PrintRawMsg(" ");

--- a/src/StoneCutter/SCOpts.cpp
+++ b/src/StoneCutter/SCOpts.cpp
@@ -187,7 +187,7 @@ void SCOpts::PrintHelp(){
   Msgs->PrintRawMsg("Options:");
   Msgs->PrintRawMsg("     -h|-help|--help                     : Print the help menu");
   Msgs->PrintRawMsg("     -k|-keep|--keep                     : Keep intermediate files");
-  Msgs->PrintRawMsg("     -c|-chisel|--chisel                 : Generate Chisel output (default=on");
+  Msgs->PrintRawMsg("     -c|-chisel|--chisel                 : Generate Chisel output (default=on)");
   Msgs->PrintRawMsg("     -p|-parse|--parse                   : Parse but do not compile");
   Msgs->PrintRawMsg("     -f|-outfile|--outfile /path/to/out  : Set the output file name");
   Msgs->PrintRawMsg("     -s|-sigmap|--sigmap /path/to/sigmap : Generates a signal map");

--- a/src/StoneCutter/SCParser.cpp
+++ b/src/StoneCutter/SCParser.cpp
@@ -79,11 +79,11 @@ void SCParser::InitIntrinsics(){
 }
 
 void SCParser::InitPassMap(){
-#if 0
+//#if 0
   EPasses.insert(std::pair<std::string,bool>("PromoteMemoryToRegisterPass",true));
   EPasses.insert(std::pair<std::string,bool>("InstructionCombiningPass",true));
   EPasses.insert(std::pair<std::string,bool>("ReassociatePass",true));
-#endif
+//#endif
   EPasses.insert(std::pair<std::string,bool>("GVNPass",true));
   EPasses.insert(std::pair<std::string,bool>("CFGSimplificationPass",true));
   EPasses.insert(std::pair<std::string,bool>("ConstantPropagationPass",true));
@@ -1047,8 +1047,18 @@ std::unique_ptr<PrototypeAST> SCParser::ParsePrototype() {
     return LogErrorP("Expected '(' in prototype");
 
   std::vector<std::string> ArgNames;
+  while (GetNextToken() == tok_identifier){
+    std::string LVar = Lex->GetIdentifierStr();
+    Value *V = SCParser::GlobalNamedValues[LVar];
+    if( !V ){
+      // not a global variable
+      ArgNames.push_back(LVar);
+    }
+  }
+#if 0
   while (GetNextToken() == tok_identifier)
     ArgNames.push_back(Lex->GetIdentifierStr());
+#endif
   if (CurTok != ')')
     return LogErrorP("Expected ')' in prototype");
 

--- a/src/StoneCutter/SCParser.cpp
+++ b/src/StoneCutter/SCParser.cpp
@@ -1980,6 +1980,9 @@ Value *InstFormatAST::codegen(){
       // add the global to the top-level names list
       GlobalNamedValues[FName] = val;
 
+      // add the field name to differentiate across other fields
+      val->addAttribute("field_name",FName);
+
       // add an attribute to track the value to the instruction format
       val->addAttribute("instformat0",Name);
 

--- a/src/StoneCutter/SCPass.cpp
+++ b/src/StoneCutter/SCPass.cpp
@@ -335,9 +335,11 @@ std::string SCPass::TraceOperand( Function &F, Value *V,
           // and see if it exists as a global
           return TraceOperand(F,Inst->getOperand(0),isPredef,isImm);
         }
-      }else if( Inst->getOpcode() == Instruction::Load ){
+      }else if( Inst->getOpcode() != Instruction::Load && Inst->hasName() ){
+        // else, examine the target of the instruction
+        Value *LHS = cast<Value>(Inst);
+        return TraceOperand(F,LHS,isPredef,isImm);
       }
-      // else, examine the remaining instructions
     }
   }
   // if we reach this point, then the source is unique

--- a/src/StoneCutter/SCPass.cpp
+++ b/src/StoneCutter/SCPass.cpp
@@ -85,7 +85,7 @@ std::vector<std::string> SCPass::GetInstFields(std::string InstFormat){
     if( AttrSet.hasAttribute("fieldtype") ){
       unsigned Idx = 0;
       while( AttrSet.hasAttribute("instformat"+std::to_string(Idx)) ){
-        if( AttrSet.getAttribute("Instformat"+std::to_string(Idx)).getValueAsString().str() ==
+        if( AttrSet.getAttribute("instformat"+std::to_string(Idx)).getValueAsString().str() ==
             InstFormat )
           Fields.push_back( Global.getName().str() );
         Idx++;
@@ -239,6 +239,15 @@ unsigned SCPass::GetNumRegClasses( std::string Var ){
   }// end for
 
   return 0;
+}
+
+std::string SCPass::TraceOperand( Function &F, Use *U, bool &isPredef ){
+  std::string OpName;
+  for( auto User : U->get()->users() ){
+    if( auto Inst = dyn_cast<Instruction>(User) ){
+    }
+  }
+  return OpName;
 }
 
 // EOF

--- a/test/DAG/IndividualPasses/KnownFail/TEST28.yaml
+++ b/test/DAG/IndividualPasses/KnownFail/TEST28.yaml
@@ -1,0 +1,1359 @@
+# -------------------------------------------------------
+# BasicRISC.yaml
+#
+# CoreGen Design Tutorial
+# Copyright 2018 Tactical Computing Laboratories, LLC
+#
+# Licensed under an Apache2 license
+# -------------------------------------------------------
+
+# -------------------------------------------------------
+# ProjectInfo Section
+# -------------------------------------------------------
+ProjectInfo:
+  - ProjectName: BasicRISC
+    ProjectRoot: ./BasicRISC
+    ProjectType: soc
+    ChiselMajorVersion: 3
+    ChiselMinorVersion: 0
+
+
+# -------------------------------------------------------
+# Register Section
+# -------------------------------------------------------
+Registers:
+  - RegName: r0
+    Width: 64
+    Index: 0
+    PseudoName: zero
+    IsFixedValue: true
+    FixedValue: 0
+    IsSIMD: false
+    RWReg: false
+    ROReg: true
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r1
+    Width: 64
+    Index: 1
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r2
+    Width: 64
+    Index: 2
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r3
+    Width: 64
+    Index: 3
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r4
+    Width: 64
+    Index: 4
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r5
+    Width: 64
+    Index: 5
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r6
+    Width: 64
+    Index: 6
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r7
+    Width: 64
+    Index: 7
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r8
+    Width: 64
+    Index: 8
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r9
+    Width: 64
+    Index: 9
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r10
+    Width: 64
+    Index: 10
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r11
+    Width: 64
+    Index: 11
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r12
+    Width: 64
+    Index: 12
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r13
+    Width: 64
+    Index: 13
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r14
+    Width: 64
+    Index: 14
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r15
+    Width: 64
+    Index: 15
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r16
+    Width: 64
+    Index: 16
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r17
+    Width: 64
+    Index: 17
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r18
+    Width: 64
+    Index: 18
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r19
+    Width: 64
+    Index: 19
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r20
+    Width: 64
+    Index: 20
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r21
+    Width: 64
+    Index: 21
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r22
+    Width: 64
+    Index: 22
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r23
+    Width: 64
+    Index: 23
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r24
+    Width: 64
+    Index: 24
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r25
+    Width: 64
+    Index: 25
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r26
+    Width: 64
+    Index: 26
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r27
+    Width: 64
+    Index: 27
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r28
+    Width: 64
+    Index: 28
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r29
+    Width: 64
+    Index: 29
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r30
+    Width: 64
+    Index: 30
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r31
+    Width: 64
+    Index: 31
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    PCReg: true
+    Shared: false
+
+  - RegName: pc
+    Width: 64
+    Index: 0
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: true
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    PCReg: true
+    Shared: false
+  - RegName: exc
+    Width: 64
+    Index: 1
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: true
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: ne
+    Width: 64
+    Index: 2
+    IsFixedValue: true
+    FixedValue: 2
+    IsSIMD: false
+    RWReg: false
+    ROReg: true
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: eq
+    Width: 64
+    Index: 3
+    IsFixedValue: true
+    FixedValue: 3
+    IsSIMD: false
+    RWReg: false
+    ROReg: true
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: gt
+    Width: 64
+    Index: 4
+    IsFixedValue: true
+    FixedValue: 4
+    IsSIMD: false
+    RWReg: false
+    ROReg: true
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: lt
+    Width: 64
+    Index: 5
+    IsFixedValue: true
+    FixedValue: 5
+    IsSIMD: false
+    RWReg: false
+    ROReg: true
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: gte
+    Width: 64
+    Index: 6
+    IsFixedValue: true
+    FixedValue: 6
+    IsSIMD: false
+    RWReg: false
+    ROReg: true
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: lte
+    Width: 64
+    Index: 7
+    IsFixedValue: true
+    FixedValue: 7
+    IsSIMD: false
+    RWReg: false
+    ROReg: true
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: sp
+    Width: 64
+    Index: 16
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: fp
+    Width: 64
+    Index: 17
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: rp
+    Width: 64
+    Index: 18
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+
+# -------------------------------------------------------
+# Register Class Section
+# -------------------------------------------------------
+RegClasses:
+  - RegisterClassName: GPR
+    Registers:
+      - r0
+      - r1
+      - r2
+      - r3
+      - r4
+      - r5
+      - r6
+      - r7
+      - r8
+      - r9
+      - r10
+      - r11
+      - r12
+      - r13
+      - r14
+      - r15
+      - r16
+      - r17
+      - r18
+      - r19
+      - r20
+      - r21
+      - r22
+      - r23
+      - r24
+      - r25
+      - r26
+      - r27
+      - r28
+      - r29
+      - r30
+      - r31
+  - RegisterClassName: CTRL
+    Registers:
+      - pc
+      - exc
+      - ne
+      - eq
+      - gt
+      - lt
+      - gte
+      - lte
+      - sp
+      - fp
+      - rp
+
+# -------------------------------------------------------
+# ISA Section
+# -------------------------------------------------------
+ISAs:
+  - ISAName: BasicRISC.ISA
+
+
+# -------------------------------------------------------
+# Instruction Format Section
+# -------------------------------------------------------
+InstFormats:
+  - InstFormatName: Arith.if
+    ISA: BasicRISC.ISA
+    FormatWidth: 32
+    Fields:
+      - FieldName: ra
+        FieldType: CGInstReg
+        FieldWidth: 5
+        StartBit: 0
+        EndBit: 4
+        MandatoryField: false
+        RegClass: GPR
+      - FieldName: rb
+        FieldType: CGInstReg
+        FieldWidth: 5
+        StartBit: 5
+        EndBit: 9
+        MandatoryField: false
+        RegClass: GPR
+      - FieldName: rt
+        FieldType: CGInstReg
+        FieldWidth: 5
+        StartBit: 10
+        EndBit: 14
+        MandatoryField: false
+        RegClass: GPR
+      - FieldName: opc
+        FieldType: CGInstCode
+        FieldWidth: 5
+        StartBit: 15
+        EndBit: 19
+        MandatoryField: true
+      - FieldName: func
+        FieldType: CGInstCode
+        FieldWidth: 5
+        StartBit: 20
+        EndBit: 24
+        MandatoryField: true
+      - FieldName: imm
+        FieldType: CGInstImm
+        FieldWidth: 7
+        StartBit: 25
+        EndBit: 31
+        MandatoryField: false
+  - InstFormatName: ReadCtrl.if
+    ISA: BasicRISC.ISA
+    FormatWidth: 32
+    Fields:
+      - FieldName: ra
+        FieldType: CGInstReg
+        FieldWidth: 5
+        StartBit: 0
+        EndBit: 4
+        MandatoryField: false
+        RegClass: GPR
+      - FieldName: rb
+        FieldType: CGInstReg
+        FieldWidth: 5
+        StartBit: 5
+        EndBit: 9
+        MandatoryField: false
+        RegClass: CTRL
+      - FieldName: rt
+        FieldType: CGInstReg
+        FieldWidth: 5
+        StartBit: 10
+        EndBit: 14
+        MandatoryField: false
+        RegClass: GPR
+      - FieldName: opc
+        FieldType: CGInstCode
+        FieldWidth: 5
+        StartBit: 15
+        EndBit: 19
+        MandatoryField: true
+      - FieldName: func
+        FieldType: CGInstCode
+        FieldWidth: 5
+        StartBit: 20
+        EndBit: 24
+        MandatoryField: true
+      - FieldName: imm
+        FieldType: CGInstImm
+        FieldWidth: 7
+        StartBit: 25
+        EndBit: 31
+        MandatoryField: false
+  - InstFormatName: WriteCtrl.if
+    ISA: BasicRISC.ISA
+    FormatWidth: 32
+    Fields:
+      - FieldName: ra
+        FieldType: CGInstReg
+        FieldWidth: 5
+        StartBit: 0
+        EndBit: 4
+        MandatoryField: false
+        RegClass: GPR
+      - FieldName: rb
+        FieldType: CGInstReg
+        FieldWidth: 5
+        StartBit: 5
+        EndBit: 9
+        MandatoryField: false
+        RegClass: GPR
+      - FieldName: rt
+        FieldType: CGInstReg
+        FieldWidth: 5
+        StartBit: 10
+        EndBit: 14
+        MandatoryField: false
+        RegClass: CTRL
+      - FieldName: opc
+        FieldType: CGInstCode
+        FieldWidth: 5
+        StartBit: 15
+        EndBit: 19
+        MandatoryField: true
+      - FieldName: func
+        FieldType: CGInstCode
+        FieldWidth: 5
+        StartBit: 20
+        EndBit: 24
+        MandatoryField: true
+      - FieldName: imm
+        FieldType: CGInstImm
+        FieldWidth: 7
+        StartBit: 25
+        EndBit: 31
+        MandatoryField: false
+
+
+# -------------------------------------------------------
+# Instruction Section
+# -------------------------------------------------------
+Insts:
+# -- Integer Arithmetic
+  - Inst: add
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = ra + rb
+  - Inst: sub
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 1
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = ra - rb
+  - Inst: mul
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = ra * rb
+  - Inst: div
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 3
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = ra / rb
+  - Inst: divu
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 4
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = ra / rb
+  - Inst: sll
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 5
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = ra << rb
+  - Inst: srl
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 6
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = ra >> rb
+  - Inst: sra
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 7
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = ra >> rb
+  - Inst: and
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 8
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = ra & rb
+  - Inst: or
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 9
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = ra | rb
+  - Inst: nand
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 10
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = NOT(ra & rb)
+  - Inst: nor
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 11
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = NOT(ra | rb)
+  - Inst: xor
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 12
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = ra ^ rb
+
+# -- Comparisons
+  - Inst: cmp.ne
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 1
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: if( ra != rb ){ rt = 2 }else{ rt = 0 }
+  - Inst: cmp.eq
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 1
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 3
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: if( ra == rb ){ rt = 3 }else{ rt = 0 }
+  - Inst: cmp.gt
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 1
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 4
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: if( ra > rb ){ rt = 4 }else{ rt = 0 }
+  - Inst: cmp.lt
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 1
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 5
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: if( ra < rb ){ rt = 5 }else{ rt = 0 }
+  - Inst: cmp.gte
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 1
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 6
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: if( ra >= rb ){ rt = 6 }else{ rt = 0 }
+  - Inst: cmp.lte
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 1
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 7
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: if( ra <= rb ){ rt = 7 }else{ rt = 0 }
+
+# -- Memory I/O
+  - Inst: lb
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+    Impl: rt = SEXT(LOADELEM(ra+imm,8))
+  - Inst: lh
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 1
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+    Impl: rt = SEXT(LOADELEM(ra+imm,16))
+  - Inst: lw
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+    Impl: rt = SEXT(LOADELEM(ra+imm,32))
+  - Inst: ld
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 3
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+    Impl: rt = LOADELEM(ra+imm,64)
+  - Inst: sb
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 4
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+    Impl: STOREELEM(ra,rt+imm,8)
+  - Inst: sh
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 5
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+    Impl: STOREELEM(SEXT(ra),rt+imm,16)
+  - Inst: sw
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 6
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+    Impl: STOREELEM(SEXT(ra),rt+imm,32)
+  - Inst: sd
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 7
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+    Impl: STOREELEM(SEXT(ra),rt+imm,64)
+  - Inst: lbu
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 16
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+    Impl: rt = ZEXT(LOADELEM(ra+imm,8))
+  - Inst: lhu
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 17
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+    Impl: rt = ZEXT(LOADELEM(ra+imm,16))
+  - Inst: lwu
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 18
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+    Impl: rt = ZEXT(LOADELEM(ra+imm,32))
+  - Inst: sbu
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 20
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+    Impl: STOREELEM(ZEXT(ra),rt+imm,8)
+  - Inst: shu
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 21
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+    Impl: STOREELEM(ZEXT(ra),rt+imm,16)
+  - Inst: swu
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 22
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+    Impl: STOREELEM(ZEXT(ra),rt+imm,32)
+
+# -- Two Operand Arithmetic
+  - Inst: not
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 3
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 15
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = NOT(ra)
+
+# -- Unconditional Branches
+  - Inst: bra
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 4
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: ra
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: pc = rt
+  - Inst: br
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 4
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 1
+      - EncodingField: ra
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: pc = SEXT(pc + rt)
+
+# -- Read from Control
+  - Inst: cadd
+    ISA: BasicRISC.ISA
+    InstFormat: ReadCtrl.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 9
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = ra + rb
+
+# -- Conditional Branches
+  - Inst: brac
+    ISA: BasicRISC.ISA
+    InstFormat: ReadCtrl.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 10
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: if( ra == rb ){ pc = rt }else{ pc = pc + 4 }
+  - Inst: brc
+    ISA: BasicRISC.ISA
+    InstFormat: ReadCtrl.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 10
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 1
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: if( ra == rb ){ pc = pc + rt }else{ pc = pc + 4 }
+
+# -- Move to Control
+  - Inst: ladd
+    ISA: BasicRISC.ISA
+    InstFormat: WriteCtrl.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 23
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = ra + rb
+
+# -- Call/Rtn Spport
+  - Inst: brr
+    ISA: BasicRISC.ISA
+    InstFormat: WriteCtrl.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 24
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+
+# -------------------------------------------------------
+# Pseudo Instruction Section
+# -------------------------------------------------------
+PseudoInsts:
+  - PseudoInst: mov
+    ISA: BasicRISC.ISA
+    Inst: add
+    Encodings:
+      - EncodingField: ra
+        EncodingWidth: 5
+        EncodingValue: 0
+  - PseudoInst: movcg
+    ISA: BasicRISC.ISA
+    Inst: cadd
+    Encodings:
+      - EncodingField: ra
+        EncodingWidth: 5
+        EncodingValue: 0
+  - PseudoInst: movgc
+    ISA: BasicRISC.ISA
+    Inst: cadd
+    Encodings:
+      - EncodingField: ra
+        EncodingWidth: 5
+        EncodingValue: 0
+
+# -------------------------------------------------------
+# Cache Section
+# -------------------------------------------------------
+Caches:
+  - Cache: Core0.L1.cache
+    Sets: 2
+    Ways: 8
+
+# -------------------------------------------------------
+# Core Section
+# -------------------------------------------------------
+Cores:
+  - Core: core0
+    ThreadUnits: 1
+    Cache: Core0.L1.cache
+    ISA: BasicRISC.ISA
+    RegisterClasses:
+      - RegClass: GPR
+      - RegClass: CTRL
+

--- a/test/DAG/IndividualPasses/KnownFail/ind_pass_test28.cpp
+++ b/test/DAG/IndividualPasses/KnownFail/ind_pass_test28.cpp
@@ -1,0 +1,58 @@
+//
+// _IND_PASS_TEST28_CPP_
+//
+// Copyright (C) 2017-2019 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+//
+
+#include <iostream>
+#include "CoreGen/CoreGenBackend/CoreGenBackend.h"
+
+std::string PROJNAME = "TEST28";
+std::string PROJROOT = "./";
+std::string ARCHROOT = "./";
+std::string PROJYAML = "../TEST28.yaml";
+
+std::string TARGETPASS = "RegSafetyPass";
+
+int main( int argc, char **argv ){
+  CoreGenBackend *CG = new CoreGenBackend(PROJNAME,
+                                          PROJROOT,
+                                          ARCHROOT);
+  if( !CG ){
+    std::cout << "ERROR : FAILED TO CREATE COREGEN OBJECT" << std::endl;
+    return -1;
+  }
+
+  if( !CG->ReadIR( PROJYAML ) ){
+    std::cout << "ERROR : FAILED TO READ YAML IR:" << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  if( !CG->BuildDAG() ){
+    std::cout << "ERROR : FAILED TO BUILD THE DAG:" << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  if( !CG->InitPassMgr() ){
+    std::cout << "ERROR : FAILED TO INIT THE PASS MANAGER:" << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  if( !CG->ExecutePass(TARGETPASS) ){
+    std::cout << "ERROR : FAILED TO EXECUTE PASS : "
+              << TARGETPASS << " : " << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  delete CG;
+  return 0;
+}

--- a/test/StoneCutter/CLI/sccomp_sigmap.sh
+++ b/test/StoneCutter/CLI/sccomp_sigmap.sh
@@ -8,10 +8,9 @@ if [ ! -f $SCCOMP_PATH/sccomp ]; then
 fi
 
 FILE=test.SIGMAP.sc
-DIR=test.SIGMAP
+DIR=test.SIGMAP.yaml
 touch $FILE
 echo "# this is a stonecutter source file" >> $FILE 2>&1
-mkdir $DIR
 
 $SCCOMP_PATH/sccomp -s $DIR $FILE
 retVal=$?

--- a/test/StoneCutter/CLI/sccomp_sigmap.sh
+++ b/test/StoneCutter/CLI/sccomp_sigmap.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+SCCOMP_PATH=$1
+
+if [ ! -f $SCCOMP_PATH/sccomp ]; then
+  echo "COULD NOT FIND $SCCOMP_PATH/sccomp"
+  exit -1
+fi
+
+FILE=test.SIGMAP.sc
+DIR=test.SIGMAP
+touch $FILE
+echo "# this is a stonecutter source file" >> $FILE 2>&1
+mkdir $DIR
+
+$SCCOMP_PATH/sccomp -s $DIR $FILE
+retVal=$?
+if [[ "$retval" -ne 0 ]]; then
+  echo "$SCCOMP_PATH/sccomp -s $DIR $FILE failed with return code = $retVal"
+  rm -Rf $FILE
+  exit $retVal
+fi
+
+$SCCOMP_PATH/sccomp -sigmap $DIR $FILE
+retVal=$?
+if [[ "$retval" -ne 0 ]]; then
+  echo "$SCCOMP_PATH/sccomp -sigmap $DIR $FILE failed with return code = $retVal"
+  rm -Rf $FILE
+  exit $retVal
+fi
+
+$SCCOMP_PATH/sccomp --sigmap $DIR $FILE
+retVal=$?
+if [[ "$retval" -ne 0 ]]; then
+  echo "$SCCOMP_PATH/sccomp --sigmap $DIR $FILE failed with return code = $retVal"
+  rm -Rf $FILE
+  exit $retVal
+fi
+
+rm -Rf $FILE $DIR
+
+exit 0

--- a/test/StoneCutter/OptParser/KnownPass/sc_optparser_test126.sc
+++ b/test/StoneCutter/OptParser/KnownPass/sc_optparser_test126.sc
@@ -1,0 +1,14 @@
+#-- sc_optparser_test126.sc
+
+regclass foo( float f1, double d2, bool b3, u7 i4,
+              u14 i5, u12 i6, u67 i7, s1024 i8, s3 i9,
+              s21 i10, s19 i11)
+regclass bar( float f1, double d2, bool b3, u7 i4,
+              u14 i5, u12 i6, u67 i7, s1024 i8, s3 i9,
+              s21 i10, s19 i11[PC])
+
+
+def foo(a b x){
+  FENCE();
+  x = FENCE();
+}

--- a/test/StoneCutter/Parser/KnownFail/sc_parser_test96_KF.sc
+++ b/test/StoneCutter/Parser/KnownFail/sc_parser_test96_KF.sc
@@ -1,0 +1,14 @@
+#-- sc_parser_test96_KF.sc
+
+regclass foo( float f1, double d2, bool b3, u7 i4,
+              u14 i5, u12 i6, u67 i7, s1024 i8, s3 i9,
+              s21 i10, s19 i11)
+regclass bar( float f1, double d2, bool b3, u7 i4,
+              u14 i5, u12 i6, u67 i7, s1024 i8, s3 i9,
+              s21 i10, s19 i11[])
+
+
+def foo(a b x){
+  FENCE();
+  x = FENCE();
+}

--- a/test/StoneCutter/Parser/KnownFail/sc_parser_test97_KF.sc
+++ b/test/StoneCutter/Parser/KnownFail/sc_parser_test97_KF.sc
@@ -1,0 +1,14 @@
+#-- sc_parser_test97_KF.sc
+
+regclass foo( float f1, double d2, bool b3, u7 i4,
+              u14 i5, u12 i6, u67 i7, s1024 i8, s3 i9,
+              s21 i10, s19 i11)
+regclass bar( float f1, double d2, bool b3, u7 i4,
+              u14 i5, u12 i6, u67 i7, s1024 i8, s3 i9,
+              s21 i10, s19 i11[PC)
+
+
+def foo(a b x){
+  FENCE();
+  x = FENCE();
+}

--- a/test/StoneCutter/Parser/KnownFail/sc_parser_test98_KF.sc
+++ b/test/StoneCutter/Parser/KnownFail/sc_parser_test98_KF.sc
@@ -1,0 +1,14 @@
+#-- sc_parser_test98_KF.sc
+
+regclass foo( float f1, double d2, bool b3, u7 i4,
+              u14 i5, u12 i6, u67 i7, s1024 i8, s3 i9,
+              s21 i10, s19 i11)
+regclass bar( float f1, double d2, bool b3, u7 i4,
+              u14 i5, u12 i6, u67 i7, s1024 i8, s3 i9,
+              s21 i10, s19 i11PC])
+
+
+def foo(a b x){
+  FENCE();
+  x = FENCE();
+}

--- a/test/StoneCutter/Parser/KnownPass/sc_parser_test126.sc
+++ b/test/StoneCutter/Parser/KnownPass/sc_parser_test126.sc
@@ -1,0 +1,14 @@
+#-- sc_parser_test126.sc
+
+regclass foo( float f1, double d2, bool b3, u7 i4,
+              u14 i5, u12 i6, u67 i7, s1024 i8, s3 i9,
+              s21 i10, s19 i11)
+regclass bar( float f1, double d2, bool b3, u7 i4,
+              u14 i5, u12 i6, u67 i7, s1024 i8, s3 i9,
+              s21 i10, s19 i11[PC])
+
+
+def foo(a b x){
+  FENCE();
+  x = FENCE();
+}

--- a/test/Yaml/Reader/BasicRISC_PC.yaml
+++ b/test/Yaml/Reader/BasicRISC_PC.yaml
@@ -1,0 +1,1358 @@
+# -------------------------------------------------------
+# BasicRISC.yaml
+#
+# CoreGen Design Tutorial
+# Copyright 2018 Tactical Computing Laboratories, LLC
+#
+# Licensed under an Apache2 license
+# -------------------------------------------------------
+
+# -------------------------------------------------------
+# ProjectInfo Section
+# -------------------------------------------------------
+ProjectInfo:
+  - ProjectName: BasicRISC
+    ProjectRoot: ./BasicRISC
+    ProjectType: soc
+    ChiselMajorVersion: 3
+    ChiselMinorVersion: 0
+
+
+# -------------------------------------------------------
+# Register Section
+# -------------------------------------------------------
+Registers:
+  - RegName: r0
+    Width: 64
+    Index: 0
+    PseudoName: zero
+    IsFixedValue: true
+    FixedValue: 0
+    IsSIMD: false
+    RWReg: false
+    ROReg: true
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r1
+    Width: 64
+    Index: 1
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r2
+    Width: 64
+    Index: 2
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r3
+    Width: 64
+    Index: 3
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r4
+    Width: 64
+    Index: 4
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r5
+    Width: 64
+    Index: 5
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r6
+    Width: 64
+    Index: 6
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r7
+    Width: 64
+    Index: 7
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r8
+    Width: 64
+    Index: 8
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r9
+    Width: 64
+    Index: 9
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r10
+    Width: 64
+    Index: 10
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r11
+    Width: 64
+    Index: 11
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r12
+    Width: 64
+    Index: 12
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r13
+    Width: 64
+    Index: 13
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r14
+    Width: 64
+    Index: 14
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r15
+    Width: 64
+    Index: 15
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r16
+    Width: 64
+    Index: 16
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r17
+    Width: 64
+    Index: 17
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r18
+    Width: 64
+    Index: 18
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r19
+    Width: 64
+    Index: 19
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r20
+    Width: 64
+    Index: 20
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r21
+    Width: 64
+    Index: 21
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r22
+    Width: 64
+    Index: 22
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r23
+    Width: 64
+    Index: 23
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r24
+    Width: 64
+    Index: 24
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r25
+    Width: 64
+    Index: 25
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r26
+    Width: 64
+    Index: 26
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r27
+    Width: 64
+    Index: 27
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r28
+    Width: 64
+    Index: 28
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r29
+    Width: 64
+    Index: 29
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r30
+    Width: 64
+    Index: 30
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: r31
+    Width: 64
+    Index: 31
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+
+  - RegName: pc
+    Width: 64
+    Index: 0
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: true
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    PCReg: true
+    Shared: false
+  - RegName: exc
+    Width: 64
+    Index: 1
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: true
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: ne
+    Width: 64
+    Index: 2
+    IsFixedValue: true
+    FixedValue: 2
+    IsSIMD: false
+    RWReg: false
+    ROReg: true
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: eq
+    Width: 64
+    Index: 3
+    IsFixedValue: true
+    FixedValue: 3
+    IsSIMD: false
+    RWReg: false
+    ROReg: true
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: gt
+    Width: 64
+    Index: 4
+    IsFixedValue: true
+    FixedValue: 4
+    IsSIMD: false
+    RWReg: false
+    ROReg: true
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: lt
+    Width: 64
+    Index: 5
+    IsFixedValue: true
+    FixedValue: 5
+    IsSIMD: false
+    RWReg: false
+    ROReg: true
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: gte
+    Width: 64
+    Index: 6
+    IsFixedValue: true
+    FixedValue: 6
+    IsSIMD: false
+    RWReg: false
+    ROReg: true
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: lte
+    Width: 64
+    Index: 7
+    IsFixedValue: true
+    FixedValue: 7
+    IsSIMD: false
+    RWReg: false
+    ROReg: true
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: sp
+    Width: 64
+    Index: 16
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: fp
+    Width: 64
+    Index: 17
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+  - RegName: rp
+    Width: 64
+    Index: 18
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: false
+    AMSReg: false
+    TUSReg: false
+    Shared: false
+
+# -------------------------------------------------------
+# Register Class Section
+# -------------------------------------------------------
+RegClasses:
+  - RegisterClassName: GPR
+    Registers:
+      - r0
+      - r1
+      - r2
+      - r3
+      - r4
+      - r5
+      - r6
+      - r7
+      - r8
+      - r9
+      - r10
+      - r11
+      - r12
+      - r13
+      - r14
+      - r15
+      - r16
+      - r17
+      - r18
+      - r19
+      - r20
+      - r21
+      - r22
+      - r23
+      - r24
+      - r25
+      - r26
+      - r27
+      - r28
+      - r29
+      - r30
+      - r31
+  - RegisterClassName: CTRL
+    Registers:
+      - pc
+      - exc
+      - ne
+      - eq
+      - gt
+      - lt
+      - gte
+      - lte
+      - sp
+      - fp
+      - rp
+
+# -------------------------------------------------------
+# ISA Section
+# -------------------------------------------------------
+ISAs:
+  - ISAName: BasicRISC.ISA
+
+
+# -------------------------------------------------------
+# Instruction Format Section
+# -------------------------------------------------------
+InstFormats:
+  - InstFormatName: Arith.if
+    ISA: BasicRISC.ISA
+    FormatWidth: 32
+    Fields:
+      - FieldName: ra
+        FieldType: CGInstReg
+        FieldWidth: 5
+        StartBit: 0
+        EndBit: 4
+        MandatoryField: false
+        RegClass: GPR
+      - FieldName: rb
+        FieldType: CGInstReg
+        FieldWidth: 5
+        StartBit: 5
+        EndBit: 9
+        MandatoryField: false
+        RegClass: GPR
+      - FieldName: rt
+        FieldType: CGInstReg
+        FieldWidth: 5
+        StartBit: 10
+        EndBit: 14
+        MandatoryField: false
+        RegClass: GPR
+      - FieldName: opc
+        FieldType: CGInstCode
+        FieldWidth: 5
+        StartBit: 15
+        EndBit: 19
+        MandatoryField: true
+      - FieldName: func
+        FieldType: CGInstCode
+        FieldWidth: 5
+        StartBit: 20
+        EndBit: 24
+        MandatoryField: true
+      - FieldName: imm
+        FieldType: CGInstImm
+        FieldWidth: 7
+        StartBit: 25
+        EndBit: 31
+        MandatoryField: false
+  - InstFormatName: ReadCtrl.if
+    ISA: BasicRISC.ISA
+    FormatWidth: 32
+    Fields:
+      - FieldName: ra
+        FieldType: CGInstReg
+        FieldWidth: 5
+        StartBit: 0
+        EndBit: 4
+        MandatoryField: false
+        RegClass: GPR
+      - FieldName: rb
+        FieldType: CGInstReg
+        FieldWidth: 5
+        StartBit: 5
+        EndBit: 9
+        MandatoryField: false
+        RegClass: CTRL
+      - FieldName: rt
+        FieldType: CGInstReg
+        FieldWidth: 5
+        StartBit: 10
+        EndBit: 14
+        MandatoryField: false
+        RegClass: GPR
+      - FieldName: opc
+        FieldType: CGInstCode
+        FieldWidth: 5
+        StartBit: 15
+        EndBit: 19
+        MandatoryField: true
+      - FieldName: func
+        FieldType: CGInstCode
+        FieldWidth: 5
+        StartBit: 20
+        EndBit: 24
+        MandatoryField: true
+      - FieldName: imm
+        FieldType: CGInstImm
+        FieldWidth: 7
+        StartBit: 25
+        EndBit: 31
+        MandatoryField: false
+  - InstFormatName: WriteCtrl.if
+    ISA: BasicRISC.ISA
+    FormatWidth: 32
+    Fields:
+      - FieldName: ra
+        FieldType: CGInstReg
+        FieldWidth: 5
+        StartBit: 0
+        EndBit: 4
+        MandatoryField: false
+        RegClass: GPR
+      - FieldName: rb
+        FieldType: CGInstReg
+        FieldWidth: 5
+        StartBit: 5
+        EndBit: 9
+        MandatoryField: false
+        RegClass: GPR
+      - FieldName: rt
+        FieldType: CGInstReg
+        FieldWidth: 5
+        StartBit: 10
+        EndBit: 14
+        MandatoryField: false
+        RegClass: CTRL
+      - FieldName: opc
+        FieldType: CGInstCode
+        FieldWidth: 5
+        StartBit: 15
+        EndBit: 19
+        MandatoryField: true
+      - FieldName: func
+        FieldType: CGInstCode
+        FieldWidth: 5
+        StartBit: 20
+        EndBit: 24
+        MandatoryField: true
+      - FieldName: imm
+        FieldType: CGInstImm
+        FieldWidth: 7
+        StartBit: 25
+        EndBit: 31
+        MandatoryField: false
+
+
+# -------------------------------------------------------
+# Instruction Section
+# -------------------------------------------------------
+Insts:
+# -- Integer Arithmetic
+  - Inst: add
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = ra + rb
+  - Inst: sub
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 1
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = ra - rb
+  - Inst: mul
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = ra * rb
+  - Inst: div
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 3
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = ra / rb
+  - Inst: divu
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 4
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = ra / rb
+  - Inst: sll
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 5
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = ra << rb
+  - Inst: srl
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 6
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = ra >> rb
+  - Inst: sra
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 7
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = ra >> rb
+  - Inst: and
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 8
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = ra & rb
+  - Inst: or
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 9
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = ra | rb
+  - Inst: nand
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 10
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = NOT(ra & rb)
+  - Inst: nor
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 11
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = NOT(ra | rb)
+  - Inst: xor
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 12
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = ra ^ rb
+
+# -- Comparisons
+  - Inst: cmp.ne
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 1
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: if( ra != rb ){ rt = 2 }else{ rt = 0 }
+  - Inst: cmp.eq
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 1
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 3
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: if( ra == rb ){ rt = 3 }else{ rt = 0 }
+  - Inst: cmp.gt
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 1
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 4
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: if( ra > rb ){ rt = 4 }else{ rt = 0 }
+  - Inst: cmp.lt
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 1
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 5
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: if( ra < rb ){ rt = 5 }else{ rt = 0 }
+  - Inst: cmp.gte
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 1
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 6
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: if( ra >= rb ){ rt = 6 }else{ rt = 0 }
+  - Inst: cmp.lte
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 1
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 7
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: if( ra <= rb ){ rt = 7 }else{ rt = 0 }
+
+# -- Memory I/O
+  - Inst: lb
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+    Impl: rt = SEXT(LOADELEM(ra+imm,8))
+  - Inst: lh
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 1
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+    Impl: rt = SEXT(LOADELEM(ra+imm,16))
+  - Inst: lw
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+    Impl: rt = SEXT(LOADELEM(ra+imm,32))
+  - Inst: ld
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 3
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+    Impl: rt = LOADELEM(ra+imm,64)
+  - Inst: sb
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 4
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+    Impl: STOREELEM(ra,rt+imm,8)
+  - Inst: sh
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 5
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+    Impl: STOREELEM(SEXT(ra),rt+imm,16)
+  - Inst: sw
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 6
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+    Impl: STOREELEM(SEXT(ra),rt+imm,32)
+  - Inst: sd
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 7
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+    Impl: STOREELEM(SEXT(ra),rt+imm,64)
+  - Inst: lbu
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 16
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+    Impl: rt = ZEXT(LOADELEM(ra+imm,8))
+  - Inst: lhu
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 17
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+    Impl: rt = ZEXT(LOADELEM(ra+imm,16))
+  - Inst: lwu
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 18
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+    Impl: rt = ZEXT(LOADELEM(ra+imm,32))
+  - Inst: sbu
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 20
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+    Impl: STOREELEM(ZEXT(ra),rt+imm,8)
+  - Inst: shu
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 21
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+    Impl: STOREELEM(ZEXT(ra),rt+imm,16)
+  - Inst: swu
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 2
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 22
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+    Impl: STOREELEM(ZEXT(ra),rt+imm,32)
+
+# -- Two Operand Arithmetic
+  - Inst: not
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 3
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 15
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = NOT(ra)
+
+# -- Unconditional Branches
+  - Inst: bra
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 4
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: ra
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: pc = rt
+  - Inst: br
+    ISA: BasicRISC.ISA
+    InstFormat: Arith.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 4
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 1
+      - EncodingField: ra
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: rb
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: pc = SEXT(pc + rt)
+
+# -- Read from Control
+  - Inst: cadd
+    ISA: BasicRISC.ISA
+    InstFormat: ReadCtrl.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 9
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = ra + rb
+
+# -- Conditional Branches
+  - Inst: brac
+    ISA: BasicRISC.ISA
+    InstFormat: ReadCtrl.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 10
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: if( ra == rb ){ pc = rt }else{ pc = pc + 4 }
+  - Inst: brc
+    ISA: BasicRISC.ISA
+    InstFormat: ReadCtrl.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 10
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 1
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: if( ra == rb ){ pc = pc + rt }else{ pc = pc + 4 }
+
+# -- Move to Control
+  - Inst: ladd
+    ISA: BasicRISC.ISA
+    InstFormat: WriteCtrl.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 23
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+    Impl: rt = ra + rb
+
+# -- Call/Rtn Spport
+  - Inst: brr
+    ISA: BasicRISC.ISA
+    InstFormat: WriteCtrl.if
+    Encodings:
+      - EncodingField: opc
+        EncodingWidth: 5
+        EncodingValue: 24
+      - EncodingField: func
+        EncodingWidth: 5
+        EncodingValue: 0
+      - EncodingField: imm
+        EncodingWidth: 7
+        EncodingValue: 0
+
+# -------------------------------------------------------
+# Pseudo Instruction Section
+# -------------------------------------------------------
+PseudoInsts:
+  - PseudoInst: mov
+    ISA: BasicRISC.ISA
+    Inst: add
+    Encodings:
+      - EncodingField: ra
+        EncodingWidth: 5
+        EncodingValue: 0
+  - PseudoInst: movcg
+    ISA: BasicRISC.ISA
+    Inst: cadd
+    Encodings:
+      - EncodingField: ra
+        EncodingWidth: 5
+        EncodingValue: 0
+  - PseudoInst: movgc
+    ISA: BasicRISC.ISA
+    Inst: cadd
+    Encodings:
+      - EncodingField: ra
+        EncodingWidth: 5
+        EncodingValue: 0
+
+# -------------------------------------------------------
+# Cache Section
+# -------------------------------------------------------
+Caches:
+  - Cache: Core0.L1.cache
+    Sets: 2
+    Ways: 8
+
+# -------------------------------------------------------
+# Core Section
+# -------------------------------------------------------
+Cores:
+  - Core: core0
+    ThreadUnits: 1
+    Cache: Core0.L1.cache
+    ISA: BasicRISC.ISA
+    RegisterClasses:
+      - RegClass: GPR
+      - RegClass: CTRL
+

--- a/test/Yaml/Reader/yaml_reader_test_87.cpp
+++ b/test/Yaml/Reader/yaml_reader_test_87.cpp
@@ -1,5 +1,5 @@
 //
-// _YAML_READER_TEST86_CPP_
+// _YAML_READER_TEST87_CPP_
 //
 // Copyright (C) 2017-2018 Tactical Computing Laboratories, LLC
 // All Rights Reserved
@@ -15,7 +15,7 @@
 std::string PROJNAME = "BasicRISC";
 std::string PROJROOT = "./";
 std::string ARCHROOT = "./";
-std::string PROJYAML = "../BasicRISC.yaml";
+std::string PROJYAML = "../BasicRISC_PC.yaml";
 
 int main( int argc, char **argv ){
   CoreGenBackend *CG = new CoreGenBackend(PROJNAME,

--- a/test/Yaml/Writer/yaml_test_79.cpp
+++ b/test/Yaml/Writer/yaml_test_79.cpp
@@ -1,0 +1,374 @@
+//
+// _YAML_TEST79_CPP_
+//
+// Copyright (C) 2017-2018 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+//
+
+#include <iostream>
+#include "CoreGen/CoreGenBackend/CoreGenBackend.h"
+
+std::string PROJNAME = "TEST79";
+std::string PROJROOT = "./";
+std::string ARCHROOT = "./";
+std::string PROJYAML = "TEST79.yaml";
+
+unsigned ITER=72;
+unsigned NUM_CORES=4;
+
+int main( int argc, char **argv ){
+  CoreGenBackend *CG = new CoreGenBackend(PROJNAME,
+                                          PROJROOT,
+                                          ARCHROOT);
+  if( !CG ){
+    std::cout << "ERROR : FAILED TO CREATE COREGEN OBJECT" << std::endl;
+    return -1;
+  }
+
+  // add an SoC
+  CoreGenSoC *SoC = CG->InsertSoC( PROJNAME + ".soc" );
+
+  // add a scratchpad
+  for( unsigned i=0; i<NUM_CORES; i++ ){
+    CoreGenSpad *Spad = CG->InsertSpad( PROJNAME + "." + std::to_string(i) + ".spad",
+                                        (i+1)*1024,
+                                        1,
+                                        1 );
+    Spad->SetStartAddr(0x800000000 + ((i+1)*1024));
+  }
+
+  // add a memory controller
+  std::vector<CoreGenMCtrl *> MCtrls;
+  for( unsigned i=0; i<NUM_CORES; i++ ){
+    MCtrls.push_back( CG->InsertMCtrl( PROJNAME + "." + std::to_string(i) + ".mctrl", 2 ) );
+  }
+
+  // add an ISA
+  CoreGenISA *ISA = CG->InsertISA( PROJNAME + ".isa" );
+
+  // add a core
+  std::vector<CoreGenCore *> Cores;
+  for( unsigned i=0; i<NUM_CORES; i++ ){
+    Cores.push_back( CG->InsertCore(PROJNAME + ".core" + std::to_string(i), ISA) );
+    Cores[i]->SetNumThreadUnits(i+1);
+  }
+
+  // add caches
+  std::vector<CoreGenCache *> L1;
+  for( unsigned i=0; i<NUM_CORES; i++ ){
+    CoreGenCache *Cache1 = CG->InsertCache( PROJNAME + ".core"
+                                            + std::to_string(i) + ".L1.cache", 1, 1 );
+    L1.push_back(Cache1);
+    if( !Cores[i]->InsertCache(Cache1) ){
+      std::cout << "ERROR : FAILED TO INSERT CACHE INTO CORE:" <<
+        CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+  }
+
+  // Shared L2
+  CoreGenCache *L2 = CG->InsertCache( PROJNAME + ".L2.cache", 2, 8 );
+  for( unsigned i=0; i<NUM_CORES; i++ ){
+    if( !L1[i]->SetChildCache( L2 ) ){
+      std::cout << "ERROR : FAILED TO SET CHILD CACHE LEVEL:" <<
+        CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+  }
+
+  // add a register class
+  CoreGenRegClass *RC = CG->InsertRegClass( PROJNAME + ".regclass" );
+  CoreGenRegClass *RCC = CG->InsertRegClass( PROJNAME + ".csrregclass" );
+
+  // insert the regclass into the cores
+  for( unsigned i=0; i<NUM_CORES; i++ ){
+    if( !Cores[i]->InsertRegClass( RC ) ){
+      std::cout << "ERROR : FAILED TO INSERT REGCLASS INTO CORE:" <<
+        CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+    if( !Cores[i]->InsertRegClass( RCC ) ){
+      std::cout << "ERROR : FAILED TO INSERT REGCLASS INTO CORE:" <<
+        CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+  }
+
+  // add a register
+  CoreGenReg *Reg[ITER];
+  for(unsigned i=0; i<ITER; i++ ){
+    Reg[i] = CG->InsertReg( PROJNAME + "." + std::to_string(i) + ".reg", i, 64 );
+    Reg[i]->SetPseudoName( "PSEUDOREG."+std::to_string(i) );
+    Reg[i]->SetAttrs(CoreGenReg::CGRegRW|CoreGenReg::CGRegTUS);
+    if( i == 0 ){
+      Reg[i]->SetAttrs(CoreGenReg::CGRegRW|CoreGenReg::CGRegTUS|CoreGenReg::CGRegPC);
+    }else{
+      Reg[i]->SetAttrs(CoreGenReg::CGRegRW|CoreGenReg::CGRegTUS);
+    }
+
+    // insert the reg into the reg class
+    if( !RC->InsertReg( Reg[i] ) ){
+      std::cout << "ERROR : FAILED TO INSERT REG INTO REGCLASS:" <<
+        CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+  }
+
+  if( !Reg[0]->InsertSubReg("SUBREG0",0,31) ){
+    std::cout << "ERROR : FAILED TO INSERT SUBREG INTO REGISTER : " << Reg[0]->GetName()
+      <<  " : " << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+  if( !Reg[0]->InsertSubReg("SUBREG1",32,63) ){
+    std::cout << "ERROR : FAILED TO INSERT SUBREG INTO REGISTER : " << Reg[0]->GetName()
+      <<  " : " << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+
+  CoreGenReg *CSR[ITER];
+  for(unsigned i=0; i<ITER; i++ ){
+    CSR[i] = CG->InsertReg( PROJNAME + "." + std::to_string(i) + ".csr", i, 64 );
+    if( CSR[i] == nullptr ){
+      std::cout << "ERROR : FAILED TO CREATE NEW REGISTER:" << CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+    CSR[i]->SetPseudoName( "CSR."+std::to_string(i) );
+    CSR[i]->SetAttrs(CoreGenReg::CGRegCSR);
+
+    if( !RCC->InsertReg(CSR[i]) ){
+      std::cout << "ERROR : FAILED TO INSERT REG INTO REGCLASS:" <<
+        CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+  }
+
+  // insert the core in the SoC
+  for( unsigned i=0; i<NUM_CORES; i++ ){
+    if( !SoC->InsertCore( Cores[i] ) ){
+      std::cout << "ERROR : FAILED TO INSERT CORE INTO SOC:" <<
+        CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+  }
+
+  // create new instruction format
+  CoreGenInstFormat *IF = CG->InsertInstFormat( PROJNAME + ".if", ISA );
+
+  // insert some instruction fields
+  //  RT     RA     RB   OPC
+  // [31-24][23-16][15-8][7-0]
+  if( !IF->InsertField( "opcode", 0, 7, CoreGenInstFormat::CGInstCode, true ) ){
+    std::cout << "ERROR : FAILED TO INSERT opcode FIELD INTO FORMAT:" <<
+      CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+  if( !IF->InsertField( "RB", 8, 15, CoreGenInstFormat::CGInstReg, false ) ){
+    std::cout << "ERROR : FAILED TO INSERT rb FIELD INTO FORMAT:" <<
+      CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+  if( !IF->InsertField( "RA", 16, 23, CoreGenInstFormat::CGInstReg, false ) ){
+    std::cout << "ERROR : FAILED TO INSERT ra FIELD INTO FORMAT:" <<
+      CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+  if( !IF->InsertField( "RT", 24, 31, CoreGenInstFormat::CGInstReg, false ) ){
+    std::cout << "ERROR : FAILED TO INSERT rt FIELD INTO FORMAT:" <<
+      CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  if( !IF->InsertRegFieldMap("RB", RC) ){
+    std::cout << "ERROR : FAILED TO SET rb FIELD REGISTER CLASS:" <<
+      CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+  if( !IF->InsertRegFieldMap("RA", RC) ){
+    std::cout << "ERROR : FAILED TO SET ra FIELD REGISTER CLASS:" <<
+      CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+  if( !IF->InsertRegFieldMap("RT", RCC) ){
+    std::cout << "ERROR : FAILED TO SET rt FIELD REGISTER CLASS:" <<
+      CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  // create a new instruction
+  CoreGenInst *Inst[ITER];
+  CoreGenPseudoInst *PInst[ITER];
+  for( unsigned i=0; i<ITER; i++ ){
+    Inst[i] = CG->InsertInst( PROJNAME + ".inst" + std::to_string(i),
+                              ISA,
+                              IF );
+    PInst[i] = CG->InsertPseudoInst( PROJNAME + ".pinst" + std::to_string(i),
+                                     Inst[i] );
+
+    if( !Inst[i]->SetImpl("RT = RA + RB") ){
+      std::cout << "ERROR : FAILED TO SET INSTRUCTION IMPL FOR INSTRUCTION: " <<
+        Inst[i]->GetName() << " : " << CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+    if( !Inst[i]->SetSyntax( PROJNAME + ".inst" + std::to_string(i) +
+                        " %RT, %RA, %RB" ) ){
+      std::cout << "ERROR : FAILED TO SET INSTRUCTION SYNTAX FOR INSTRUCTION: " <<
+        Inst[i]->GetName() << " : " << CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+
+    if( !Inst[i]->SetEncoding("opcode",i+1) ){
+      std::cout << "ERROR : FAILED TO SET opcode ENCODING FOR INSTRUCTION: " <<
+        Inst[i]->GetName() << " : " << CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+
+    if( !PInst[i]->SetEncoding("RA",i) ){
+      std::cout << "ERROR : FAILED TO SET ra ENCODING FOR PSEUDO INSTRUCTION: " <<
+        Inst[i]->GetName() << " : " << CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+  }
+
+  // insert a new Ext node
+  CoreGenExt *E[NUM_CORES];
+  for( unsigned i=0; i<NUM_CORES; i++ ){
+    E[i] = CG->InsertExt( PROJNAME + ".ext" + std::to_string(i) );
+
+    if( !E[i]->SetRTL("when( RA === 0x05){RT = RA << RB}" ) ){
+      std::cout << "ERROR : FAILED TO SET RTL FILE : "
+        << CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+
+    if( !E[i]->SetRTLType( RTLVerilog ) ){
+      std::cout << "ERROR : FAILED TO SET RTL TYPE : "
+        << CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+
+    CoreGenRegClass *ERC = E[i]->InsertRegClass( PROJNAME +
+                                              ".ext" + std::to_string(i) +
+                                              ".regclass" );
+    CoreGenISA *EISA = E[i]->InsertISA( PROJNAME + ".ext" + std::to_string(i) +
+                                     ".isa" );
+    CoreGenReg *EREG  = E[i]->InsertReg( PROJNAME + ".ext" + std::to_string(i) +
+                                      ".reg", 0, 64 );
+    if( !ERC->InsertReg(EREG ) ){
+      std::cout << "ERROR : FAILED TO INSERT EXT REGISTER INTO EXT REGISTER CLASS : "
+        << CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+  }
+
+  for( unsigned i=0; i<Cores.size(); i++ ){
+    if( !Cores[i]->InsertExt( E[i] ) ){
+      std::cout << "ERROR : FAILED TO INSERT EXTENSION FOR CORE " << i <<" : "
+        << CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+  }
+
+  // insert a new VTP node
+  CoreGenVTP *M = CG->InsertVTP( PROJNAME + ".vtp" );
+  if( !M ){
+    std::cout << "ERROR : FAILED TO INSERT NEW VIRTUAL TO PHYSICAL NODE "
+              << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  // insert a comm node
+  CoreGenComm *COMM = CG->InsertComm( PROJNAME + ".comm" );
+  if( !COMM ){
+    std::cout << "ERROR : FAILED TO INSERT NEW COMM NODE "
+              << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  if( !COMM->SetCommType(CGCommNoc) ){
+    std::cout << "ERROR : FAILED TO SET COMM NODE TYPE "
+              << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  if( !COMM->SetWidth(64) ){
+    std::cout << "ERROR : FAILED TO SET COMM NODE WIDTH "
+              << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  for( unsigned i=0; i<Cores.size(); i++ ){
+    if( !COMM->InsertEndpoint( static_cast<CoreGenNode *>(Cores[i]) ) ){
+      std::cout << "ERROR : FAILED TO INSERT COMM LINK FOR CORE " << i
+                << " : " << CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+  }
+
+  if( !COMM->InsertEndpoint( static_cast<CoreGenNode *>(L2) ) ){
+    std::cout << "ERROR : FAILED TO INSERT L2 CACHE INTO COMM LINK "
+              << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  if( !COMM->InsertEndpoint( static_cast<CoreGenNode *>(M) ) ){
+    std::cout << "ERROR : FAILED TO INSERT VTP LAYER INTO COMM LINK "
+              << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  for( unsigned i=0; i<MCtrls.size(); i++ ){
+    if( !COMM->InsertEndpoint( static_cast<CoreGenNode *>(MCtrls[i]) ) ){
+      std::cout << "ERROR : FAILED TO INSERT COMM LINK FOR MCTRL " << i
+                << " : " << CG->GetErrStr() << std::endl;
+      delete CG;
+      return -1;
+    }
+  }
+
+  // write the yaml
+  if( !CG->WriteIR( PROJYAML ) ){
+    std::cout << "ERROR : FAILED TO WRITE YAML IR:" << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  delete CG;
+  return 0;
+}


### PR DESCRIPTION
This merge supports the ability to define registers with a "PC" or program counter attribute.  This attribute can also be annotated in the StoneCutter language.  CoreGen executes a series of additional passes across the design in order to ensure that there are no duplicate PC registers within an ISA.  StoneCutter utilizes this register to define the necessary signal handlers for the design. 