### PR TITLE
Removing unnecessary library for linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ sudo apt-get update
 ```
 2.  Install the system dependencies:
 ```
-sudo apt-get install -y libllvm-6.0-ocaml-dev libllvm6.0 llvm-6.0 llvm-6.0-dev llvm-6.0-doc llvm-6.0-examples llvm-6.0-runtime clang-6.0 clang-tools-6.0 clang-6.0-doc libclang-common-6.0-dev libclang-6.0-dev libclang1-6.0 clang-format-6.0 python-clang-6.0 re2c lua5.3 liblua5.3-dev
+sudo apt-get install -y libllvm-6.0-ocaml-dev libllvm6.0 llvm-6.0 llvm-6.0-dev llvm-6.0-doc llvm-6.0-examples llvm-6.0-runtime clang-6.0 clang-tools-6.0 clang-6.0-doc libclang-common-6.0-dev libclang-6.0-dev libclang1-6.0 clang-format-6.0 python-clang-6.0 re2c lua5.3 liblua5.3-dev zlib1g zlib1g-dev bison
 ```
 3. Clone the CoreGen repository
 ```

--- a/src/CoreGenBackend/CMakeLists.txt
+++ b/src/CoreGenBackend/CMakeLists.txt
@@ -47,7 +47,8 @@ link_directories(${CMAKE_ARCHIVE_OUTPUT_DIRECTORY})
 add_library(CoreGenBackend ${CoreGenSrcs} $<TARGET_OBJECTS:DataPassObjs>
                                           $<TARGET_OBJECTS:AnalysisPassObjs>
                                           $<TARGET_OBJECTS:OptPassObjs>)
-target_link_libraries(CoreGenBackend CoreGenPluginImpl CoreGenCodegen yaml-cpp libclingo libpyclingo libluaclingo ${COREGEN_LINK_LIBS})
+#target_link_libraries(CoreGenBackend CoreGenPluginImpl CoreGenCodegen yaml-cpp libclingo libpyclingo libluaclingo ${COREGEN_LINK_LIBS})
+target_link_libraries(CoreGenBackend CoreGenPluginImpl CoreGenCodegen yaml-cpp libclingo libluaclingo ${COREGEN_LINK_LIBS})
 target_compile_options(CoreGenBackend PRIVATE -fPIC)
 
 install(TARGETS CoreGenBackend DESTINATION lib)

--- a/src/CoreGenBackend/CMakeLists.txt
+++ b/src/CoreGenBackend/CMakeLists.txt
@@ -47,7 +47,6 @@ link_directories(${CMAKE_ARCHIVE_OUTPUT_DIRECTORY})
 add_library(CoreGenBackend ${CoreGenSrcs} $<TARGET_OBJECTS:DataPassObjs>
                                           $<TARGET_OBJECTS:AnalysisPassObjs>
                                           $<TARGET_OBJECTS:OptPassObjs>)
-#target_link_libraries(CoreGenBackend CoreGenPluginImpl CoreGenCodegen yaml-cpp libclingo libpyclingo libluaclingo ${COREGEN_LINK_LIBS})
 target_link_libraries(CoreGenBackend CoreGenPluginImpl CoreGenCodegen yaml-cpp libclingo libluaclingo ${COREGEN_LINK_LIBS})
 target_compile_options(CoreGenBackend PRIVATE -fPIC)
 


### PR DESCRIPTION
Removing pyclingo library dep at link time.  This is a fix for Issue #201; merging into devel