### PR TITLE
Adding syntax to support field width definitions in StoneCutter

### DIFF
--- a/include/CoreGen/StoneCutter/SCParser.h
+++ b/include/CoreGen/StoneCutter/SCParser.h
@@ -305,14 +305,16 @@ public:
     std::string Name;   ///< Name of the instruction format
     std::vector<std::tuple<std::string,
                            SCInstField,
-                           std::string>> Fields; ///< Field vector
+                           std::string,
+                           unsigned>> Fields; ///< Field vector
 
   public:
     /// InstFormatASTContainer default constructor
     InstFormatASTContainer(const std::string &Name,
                            std::vector<std::tuple<std::string,
                                                   SCInstField,
-                                                  std::string>> Fields)
+                                                  std::string,
+                                                  unsigned>> Fields)
       : Name(Name), Fields(std::move(Fields)) {}
 
     /// InstFormatASTContainer: Retrieve the name of an instruction format

--- a/include/CoreGen/StoneCutter/SCPass.h
+++ b/include/CoreGen/StoneCutter/SCPass.h
@@ -125,6 +125,9 @@ public:
   /// Retrieves the set of register classes for fields that match the instruction format
   std::vector<std::string> GetRegClassInstTypes(std::string InstFormat);
 
+  /// Retrieves the instruction width field for the target instruction format and the target field
+  bool GetInstFieldWidth(std::string InstFormat, std::string Field, unsigned& Width );
+
   /// Retrieves the number of pipeline stages contained within the target function
   unsigned GetNumPipeStages(Function &F);
 

--- a/src/CoreGenCodegen/CoreGenCodegen.cpp
+++ b/src/CoreGenCodegen/CoreGenCodegen.cpp
@@ -516,13 +516,16 @@ bool CoreGenCodegen::BuildISAChisel( CoreGenISA *ISA,
           MOutFile << "reg["
                    << IF[i]->GetFieldRegClass(IF[i]->GetFieldName(j))->GetName()
                    << "] "
-                   << IF[i]->GetFieldName(j);
+                   << IF[i]->GetFieldName(j)
+                   << ":" << IF[i]->GetFieldWidth(IF[i]->GetFieldName(j));
           break;
         case CoreGenInstFormat::CGInstCode:
-          MOutFile << "enc " << IF[i]->GetFieldName(j);
+          MOutFile << "enc " << IF[i]->GetFieldName(j)
+                   << ":" << IF[i]->GetFieldWidth(IF[i]->GetFieldName(j));
           break;
         case CoreGenInstFormat::CGInstImm:
-          MOutFile << "imm " << IF[i]->GetFieldName(j);
+          MOutFile << "imm " << IF[i]->GetFieldName(j)
+                   << ":" << IF[i]->GetFieldWidth(IF[i]->GetFieldName(j));
           break;
         default:
           Errno->SetError(CGERR_ERROR,

--- a/src/StoneCutter/SCPass.cpp
+++ b/src/StoneCutter/SCPass.cpp
@@ -97,6 +97,35 @@ std::vector<std::string> SCPass::GetInstFields(std::string InstFormat){
   return Fields;
 }
 
+bool SCPass::GetInstFieldWidth( std::string InstFormat,
+                                std::string Field,
+                                unsigned& Width ){
+
+  for( auto &Global : TheModule->getGlobalList() ){
+    AttributeSet AttrSet = Global.getAttributes();
+    if( AttrSet.hasAttribute("fieldtype") ){
+      if( AttrSet.getAttribute("field_name").getValueAsString().str() == Field ){
+        unsigned Idx = 0;
+        while( AttrSet.hasAttribute("instformat"+std::to_string(Idx)) ){
+          if( AttrSet.getAttribute("instformat"+std::to_string(Idx)).getValueAsString().str() ==
+              InstFormat ){
+            // found the inst format at Index=Idx
+            if( AttrSet.hasAttribute("instwidth"+std::to_string(Idx)) ){
+              // found the target width
+              std::string TW = AttrSet.getAttribute("instwidth"+std::to_string(Idx)).getValueAsString().str();
+              Width = std::stoi(TW,nullptr,0);
+              return true;
+            }
+          }
+          Idx++;
+        }
+      }
+    }
+  }
+
+  return false;
+}
+
 std::vector<std::string> SCPass::GetRegClassInstFields(std::string InstFormat){
   std::vector<std::string> Fields;
 
@@ -185,8 +214,6 @@ std::vector<std::string> SCPass::GetRegClassInstTypes(std::string InstFormat){
   Fields.erase( std::unique(Fields.begin(),Fields.end()), Fields.end() );
   return Fields;
 }
-
-
 
 std::string SCPass::GetGlobalAttribute( std::string Var,
                                         std::string Attribute ){

--- a/test/StoneCutter/OptParser/KnownPass/sc_optparser_test137.sc
+++ b/test/StoneCutter/OptParser/KnownPass/sc_optparser_test137.sc
@@ -1,0 +1,24 @@
+#-- sc_parser_test135.sc
+
+instformat F1( enc field1:5, imm field2:5, reg[foo] field3:5, reg[bar] field4:5 )
+instformat F2( enc field1, imm field2, reg[foo] field3, reg[bar] field4 )
+
+regclass foo( float f1, double d2, bool b3, u7 i4,
+              u14 i5, u12 i6, u67 i7, s1024 i8, s3 i9,
+              s21 i10, s19 i11)
+regclass bar( float f1, double d2, bool b3, u7 i4,
+              u14 i5, u12 i6, u67 i7, s1024 i8, s3 i9,
+              s21 i10, s19 i11)
+
+
+def foo:F2(a b c field3){
+  u64 newreg
+  while( a != b ){
+    if( a < 10 ){
+      a = a + 1
+    }else{
+      a = a + 2
+      c = a + 5
+    }
+  }
+}

--- a/test/StoneCutter/OptParser/KnownPass/sc_optparser_test138.sc
+++ b/test/StoneCutter/OptParser/KnownPass/sc_optparser_test138.sc
@@ -1,0 +1,24 @@
+#-- sc_parser_test135.sc
+
+instformat F1( enc field1:5, imm field2:5, reg[foo] field3, reg[bar] field4 )
+instformat F2( enc field1, imm field2, reg[foo] field3, reg[bar] field4 )
+
+regclass foo( float f1, double d2, bool b3, u7 i4,
+              u14 i5, u12 i6, u67 i7, s1024 i8, s3 i9,
+              s21 i10, s19 i11)
+regclass bar( float f1, double d2, bool b3, u7 i4,
+              u14 i5, u12 i6, u67 i7, s1024 i8, s3 i9,
+              s21 i10, s19 i11)
+
+
+def foo:F2(a b c field3){
+  u64 newreg
+  while( a != b ){
+    if( a < 10 ){
+      a = a + 1
+    }else{
+      a = a + 2
+      c = a + 5
+    }
+  }
+}

--- a/test/StoneCutter/Parser/KnownFail/sc_parser_test106_KF.sc
+++ b/test/StoneCutter/Parser/KnownFail/sc_parser_test106_KF.sc
@@ -1,0 +1,24 @@
+#-- sc_parser_test135.sc
+
+instformat F1( enc field1:5, imm field2:5, reg[foo] field3:5, reg[bar] field4: )
+instformat F2( enc field1, imm field2, reg[foo] field3, reg[bar] field4 )
+
+regclass foo( float f1, double d2, bool b3, u7 i4,
+              u14 i5, u12 i6, u67 i7, s1024 i8, s3 i9,
+              s21 i10, s19 i11)
+regclass bar( float f1, double d2, bool b3, u7 i4,
+              u14 i5, u12 i6, u67 i7, s1024 i8, s3 i9,
+              s21 i10, s19 i11)
+
+
+def foo:F2(a b c field3){
+  u64 newreg
+  while( a != b ){
+    if( a < 10 ){
+      a = a + 1
+    }else{
+      a = a + 2
+      c = a + 5
+    }
+  }
+}

--- a/test/StoneCutter/Parser/KnownPass/sc_parser_test135.sc
+++ b/test/StoneCutter/Parser/KnownPass/sc_parser_test135.sc
@@ -1,0 +1,24 @@
+#-- sc_parser_test135.sc
+
+instformat F1( enc field1:5, imm field2:5, reg[foo] field3:5, reg[bar] field4:5 )
+instformat F2( enc field1, imm field2, reg[foo] field3, reg[bar] field4 )
+
+regclass foo( float f1, double d2, bool b3, u7 i4,
+              u14 i5, u12 i6, u67 i7, s1024 i8, s3 i9,
+              s21 i10, s19 i11)
+regclass bar( float f1, double d2, bool b3, u7 i4,
+              u14 i5, u12 i6, u67 i7, s1024 i8, s3 i9,
+              s21 i10, s19 i11)
+
+
+def foo:F2(a b c field3){
+  u64 newreg
+  while( a != b ){
+    if( a < 10 ){
+      a = a + 1
+    }else{
+      a = a + 2
+      c = a + 5
+    }
+  }
+}

--- a/test/StoneCutter/Parser/KnownPass/sc_parser_test136.sc
+++ b/test/StoneCutter/Parser/KnownPass/sc_parser_test136.sc
@@ -1,0 +1,24 @@
+#-- sc_parser_test135.sc
+
+instformat F1( enc field1:5, imm field2:5, reg[foo] field3, reg[bar] field4 )
+instformat F2( enc field1, imm field2, reg[foo] field3, reg[bar] field4 )
+
+regclass foo( float f1, double d2, bool b3, u7 i4,
+              u14 i5, u12 i6, u67 i7, s1024 i8, s3 i9,
+              s21 i10, s19 i11)
+regclass bar( float f1, double d2, bool b3, u7 i4,
+              u14 i5, u12 i6, u67 i7, s1024 i8, s3 i9,
+              s21 i10, s19 i11)
+
+
+def foo:F2(a b c field3){
+  u64 newreg
+  while( a != b ){
+    if( a < 10 ){
+      a = a + 1
+    }else{
+      a = a + 2
+      c = a + 5
+    }
+  }
+}


### PR DESCRIPTION
This allows for syntax to define the width of target instfield.  Adding tests and updating CoreGenCodegen to account for the changes.  Fix for Issue #156 