### PR TITLE
adding cache line size parameter that defaults to 64 bytes

### DIFF
--- a/include/CoreGen/CoreGenBackend/CoreGenCache.h
+++ b/include/CoreGen/CoreGenBackend/CoreGenCache.h
@@ -31,6 +31,7 @@ class CoreGenCache : public CoreGenNode{
 private:
   unsigned Sets;        ///< CoreGenCache: Number of sets
   unsigned Ways;        ///< CoreGenCache: Number of ways
+  unsigned LineSize;    ///< CoreGenCache: Size of each cache line in bytes
   bool SubLevel;        ///< CoreGenCache: Is this a sublevel?
   bool ParentLevel;     ///< CoreGenCache: Is this a parent level?
   CoreGenCache *Child;  ///< CoreGenCache: Child cache level
@@ -50,6 +51,12 @@ public:
 
   /// Retrieve the number of ways
   unsigned GetWays() { return Ways; }
+
+  /// Retrieve the size of each cache line
+  unsigned GetLineSize() { return LineSize; }
+
+  /// Sets the size of each cache line in bytes
+  bool SetLineSize(unsigned S) { LineSize = S; return true; }
 
   /// Set the number of sets
   bool SetSets( unsigned S ) { Sets = S; return true; }

--- a/src/CoreGenBackend/CoreGenCache.cpp
+++ b/src/CoreGenBackend/CoreGenCache.cpp
@@ -11,13 +11,13 @@
 #include "CoreGen/CoreGenBackend/CoreGenCache.h"
 
 CoreGenCache::CoreGenCache(std::string N, CoreGenErrno *E )
-  : CoreGenNode(CGCache,E), Sets(0), Ways(0), SubLevel(false),
-    ParentLevel(false), Child(nullptr){
+  : CoreGenNode(CGCache,E), Sets(0), Ways(0), LineSize(64),
+    SubLevel(false), ParentLevel(false), Child(nullptr){
 }
 
 CoreGenCache::CoreGenCache(std::string N, unsigned CSets,
                             unsigned CWays, CoreGenErrno *E)
-  : CoreGenNode(CGCache,N,E), Sets(CSets), Ways(CWays),
+  : CoreGenNode(CGCache,N,E), Sets(CSets), Ways(CWays), LineSize(64),
     SubLevel(false), ParentLevel(false), Child(nullptr){
 }
 

--- a/src/CoreGenBackend/CoreGenInstFormat.cpp
+++ b/src/CoreGenBackend/CoreGenInstFormat.cpp
@@ -211,8 +211,6 @@ CoreGenInstFormat::CGInstField CoreGenInstFormat::GetFieldType( std::string Name
 }
 
 bool CoreGenInstFormat::SetNullField( std::string Name ){
-  std::vector<std::tuple<std::string,unsigned,unsigned,CGInstField,bool>>::iterator it;
-
   // nullify the field
   if( !this->SetFieldType(Name,CoreGenInstFormat::CGInstUnk) )
     return false;

--- a/src/CoreGenBackend/CoreGenYaml.cpp
+++ b/src/CoreGenBackend/CoreGenYaml.cpp
@@ -446,6 +446,8 @@ void CoreGenYaml::PrintCache( YAML::Emitter *out,
   *out << YAML::Value << Cache->GetSets();
   *out << YAML::Key << "Ways";
   *out << YAML::Value << Cache->GetWays();
+  *out << YAML::Key << "LineSize";
+  *out << YAML::Value << Cache->GetLineSize();
   if( Cache->IsParentLevel() &&
       (Cache->GetSubCache() != nullptr) ){
     *out << YAML::Key << "SubLevel";
@@ -2587,6 +2589,11 @@ bool CoreGenYaml::ReadCacheYaml(const YAML::Node& CacheNodes,
 
     int Sets = Node["Sets"].as<int>();
     int Ways = Node["Ways"].as<int>();
+    unsigned LineSize = 64;
+
+    if( CheckValidNode(Node,"LineSize") ){
+      LineSize = Node["LineSize"].as<unsigned>();
+    }
 
     ASP += "cache(" + ASPName + ").\n";
     ASP += "cacheSets(" + ASPName + ", " + std::to_string(Sets) + ").\n";

--- a/test/Yaml/Reader/TEST95.yaml
+++ b/test/Yaml/Reader/TEST95.yaml
@@ -1,0 +1,3056 @@
+ProjectInfo:
+  - ProjectName: TEST87
+    ProjectRoot: ./
+    ProjectType: unknown
+    ChiselMajorVersion: 3
+    ChiselMinorVersion: 0
+Registers:
+  - RegName: TEST87.0.reg
+    Width: 64
+    Index: 0
+    PseudoName: pseudoreg.0
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: true
+    Shared: false
+    SubRegs:
+      - SubReg: SUBREG0
+        StartBit: 0
+        EndBit: 31
+      - SubReg: SUBREG1
+        StartBit: 32
+        EndBit: 63
+  - RegName: TEST87.1.reg
+    Width: 64
+    Index: 1
+    PseudoName: pseudoreg.1
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.2.reg
+    Width: 64
+    Index: 2
+    PseudoName: pseudoreg.2
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.3.reg
+    Width: 64
+    Index: 3
+    PseudoName: pseudoreg.3
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.4.reg
+    Width: 64
+    Index: 4
+    PseudoName: pseudoreg.4
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.5.reg
+    Width: 64
+    Index: 5
+    PseudoName: pseudoreg.5
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.6.reg
+    Width: 64
+    Index: 6
+    PseudoName: pseudoreg.6
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.7.reg
+    Width: 64
+    Index: 7
+    PseudoName: pseudoreg.7
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.8.reg
+    Width: 64
+    Index: 8
+    PseudoName: pseudoreg.8
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.9.reg
+    Width: 64
+    Index: 9
+    PseudoName: pseudoreg.9
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.10.reg
+    Width: 64
+    Index: 10
+    PseudoName: pseudoreg.10
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.11.reg
+    Width: 64
+    Index: 11
+    PseudoName: pseudoreg.11
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.12.reg
+    Width: 64
+    Index: 12
+    PseudoName: pseudoreg.12
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.13.reg
+    Width: 64
+    Index: 13
+    PseudoName: pseudoreg.13
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.14.reg
+    Width: 64
+    Index: 14
+    PseudoName: pseudoreg.14
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.15.reg
+    Width: 64
+    Index: 15
+    PseudoName: pseudoreg.15
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.16.reg
+    Width: 64
+    Index: 16
+    PseudoName: pseudoreg.16
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.17.reg
+    Width: 64
+    Index: 17
+    PseudoName: pseudoreg.17
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.18.reg
+    Width: 64
+    Index: 18
+    PseudoName: pseudoreg.18
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.19.reg
+    Width: 64
+    Index: 19
+    PseudoName: pseudoreg.19
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.20.reg
+    Width: 64
+    Index: 20
+    PseudoName: pseudoreg.20
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.21.reg
+    Width: 64
+    Index: 21
+    PseudoName: pseudoreg.21
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.22.reg
+    Width: 64
+    Index: 22
+    PseudoName: pseudoreg.22
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.23.reg
+    Width: 64
+    Index: 23
+    PseudoName: pseudoreg.23
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.24.reg
+    Width: 64
+    Index: 24
+    PseudoName: pseudoreg.24
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.25.reg
+    Width: 64
+    Index: 25
+    PseudoName: pseudoreg.25
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.26.reg
+    Width: 64
+    Index: 26
+    PseudoName: pseudoreg.26
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.27.reg
+    Width: 64
+    Index: 27
+    PseudoName: pseudoreg.27
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.28.reg
+    Width: 64
+    Index: 28
+    PseudoName: pseudoreg.28
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.29.reg
+    Width: 64
+    Index: 29
+    PseudoName: pseudoreg.29
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.30.reg
+    Width: 64
+    Index: 30
+    PseudoName: pseudoreg.30
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.31.reg
+    Width: 64
+    Index: 31
+    PseudoName: pseudoreg.31
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.32.reg
+    Width: 64
+    Index: 32
+    PseudoName: pseudoreg.32
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.33.reg
+    Width: 64
+    Index: 33
+    PseudoName: pseudoreg.33
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.34.reg
+    Width: 64
+    Index: 34
+    PseudoName: pseudoreg.34
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.35.reg
+    Width: 64
+    Index: 35
+    PseudoName: pseudoreg.35
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.36.reg
+    Width: 64
+    Index: 36
+    PseudoName: pseudoreg.36
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.37.reg
+    Width: 64
+    Index: 37
+    PseudoName: pseudoreg.37
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.38.reg
+    Width: 64
+    Index: 38
+    PseudoName: pseudoreg.38
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.39.reg
+    Width: 64
+    Index: 39
+    PseudoName: pseudoreg.39
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.40.reg
+    Width: 64
+    Index: 40
+    PseudoName: pseudoreg.40
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.41.reg
+    Width: 64
+    Index: 41
+    PseudoName: pseudoreg.41
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.42.reg
+    Width: 64
+    Index: 42
+    PseudoName: pseudoreg.42
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.43.reg
+    Width: 64
+    Index: 43
+    PseudoName: pseudoreg.43
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.44.reg
+    Width: 64
+    Index: 44
+    PseudoName: pseudoreg.44
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.45.reg
+    Width: 64
+    Index: 45
+    PseudoName: pseudoreg.45
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.46.reg
+    Width: 64
+    Index: 46
+    PseudoName: pseudoreg.46
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.47.reg
+    Width: 64
+    Index: 47
+    PseudoName: pseudoreg.47
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.48.reg
+    Width: 64
+    Index: 48
+    PseudoName: pseudoreg.48
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.49.reg
+    Width: 64
+    Index: 49
+    PseudoName: pseudoreg.49
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.50.reg
+    Width: 64
+    Index: 50
+    PseudoName: pseudoreg.50
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.51.reg
+    Width: 64
+    Index: 51
+    PseudoName: pseudoreg.51
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.52.reg
+    Width: 64
+    Index: 52
+    PseudoName: pseudoreg.52
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.53.reg
+    Width: 64
+    Index: 53
+    PseudoName: pseudoreg.53
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.54.reg
+    Width: 64
+    Index: 54
+    PseudoName: pseudoreg.54
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.55.reg
+    Width: 64
+    Index: 55
+    PseudoName: pseudoreg.55
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.56.reg
+    Width: 64
+    Index: 56
+    PseudoName: pseudoreg.56
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.57.reg
+    Width: 64
+    Index: 57
+    PseudoName: pseudoreg.57
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.58.reg
+    Width: 64
+    Index: 58
+    PseudoName: pseudoreg.58
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.59.reg
+    Width: 64
+    Index: 59
+    PseudoName: pseudoreg.59
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.60.reg
+    Width: 64
+    Index: 60
+    PseudoName: pseudoreg.60
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.61.reg
+    Width: 64
+    Index: 61
+    PseudoName: pseudoreg.61
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.62.reg
+    Width: 64
+    Index: 62
+    PseudoName: pseudoreg.62
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.63.reg
+    Width: 64
+    Index: 63
+    PseudoName: pseudoreg.63
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.64.reg
+    Width: 64
+    Index: 64
+    PseudoName: pseudoreg.64
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.65.reg
+    Width: 64
+    Index: 65
+    PseudoName: pseudoreg.65
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.66.reg
+    Width: 64
+    Index: 66
+    PseudoName: pseudoreg.66
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.67.reg
+    Width: 64
+    Index: 67
+    PseudoName: pseudoreg.67
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.68.reg
+    Width: 64
+    Index: 68
+    PseudoName: pseudoreg.68
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.69.reg
+    Width: 64
+    Index: 69
+    PseudoName: pseudoreg.69
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.70.reg
+    Width: 64
+    Index: 70
+    PseudoName: pseudoreg.70
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.71.reg
+    Width: 64
+    Index: 71
+    PseudoName: pseudoreg.71
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: true
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: true
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.0.csr
+    Width: 64
+    Index: 0
+    PseudoName: csr.0
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.1.csr
+    Width: 64
+    Index: 1
+    PseudoName: csr.1
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.2.csr
+    Width: 64
+    Index: 2
+    PseudoName: csr.2
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.3.csr
+    Width: 64
+    Index: 3
+    PseudoName: csr.3
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.4.csr
+    Width: 64
+    Index: 4
+    PseudoName: csr.4
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.5.csr
+    Width: 64
+    Index: 5
+    PseudoName: csr.5
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.6.csr
+    Width: 64
+    Index: 6
+    PseudoName: csr.6
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.7.csr
+    Width: 64
+    Index: 7
+    PseudoName: csr.7
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.8.csr
+    Width: 64
+    Index: 8
+    PseudoName: csr.8
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.9.csr
+    Width: 64
+    Index: 9
+    PseudoName: csr.9
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.10.csr
+    Width: 64
+    Index: 10
+    PseudoName: csr.10
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.11.csr
+    Width: 64
+    Index: 11
+    PseudoName: csr.11
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.12.csr
+    Width: 64
+    Index: 12
+    PseudoName: csr.12
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.13.csr
+    Width: 64
+    Index: 13
+    PseudoName: csr.13
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.14.csr
+    Width: 64
+    Index: 14
+    PseudoName: csr.14
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.15.csr
+    Width: 64
+    Index: 15
+    PseudoName: csr.15
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.16.csr
+    Width: 64
+    Index: 16
+    PseudoName: csr.16
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.17.csr
+    Width: 64
+    Index: 17
+    PseudoName: csr.17
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.18.csr
+    Width: 64
+    Index: 18
+    PseudoName: csr.18
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.19.csr
+    Width: 64
+    Index: 19
+    PseudoName: csr.19
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.20.csr
+    Width: 64
+    Index: 20
+    PseudoName: csr.20
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.21.csr
+    Width: 64
+    Index: 21
+    PseudoName: csr.21
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.22.csr
+    Width: 64
+    Index: 22
+    PseudoName: csr.22
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.23.csr
+    Width: 64
+    Index: 23
+    PseudoName: csr.23
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.24.csr
+    Width: 64
+    Index: 24
+    PseudoName: csr.24
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.25.csr
+    Width: 64
+    Index: 25
+    PseudoName: csr.25
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.26.csr
+    Width: 64
+    Index: 26
+    PseudoName: csr.26
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.27.csr
+    Width: 64
+    Index: 27
+    PseudoName: csr.27
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.28.csr
+    Width: 64
+    Index: 28
+    PseudoName: csr.28
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.29.csr
+    Width: 64
+    Index: 29
+    PseudoName: csr.29
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.30.csr
+    Width: 64
+    Index: 30
+    PseudoName: csr.30
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.31.csr
+    Width: 64
+    Index: 31
+    PseudoName: csr.31
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.32.csr
+    Width: 64
+    Index: 32
+    PseudoName: csr.32
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.33.csr
+    Width: 64
+    Index: 33
+    PseudoName: csr.33
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.34.csr
+    Width: 64
+    Index: 34
+    PseudoName: csr.34
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.35.csr
+    Width: 64
+    Index: 35
+    PseudoName: csr.35
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.36.csr
+    Width: 64
+    Index: 36
+    PseudoName: csr.36
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.37.csr
+    Width: 64
+    Index: 37
+    PseudoName: csr.37
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.38.csr
+    Width: 64
+    Index: 38
+    PseudoName: csr.38
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.39.csr
+    Width: 64
+    Index: 39
+    PseudoName: csr.39
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.40.csr
+    Width: 64
+    Index: 40
+    PseudoName: csr.40
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.41.csr
+    Width: 64
+    Index: 41
+    PseudoName: csr.41
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.42.csr
+    Width: 64
+    Index: 42
+    PseudoName: csr.42
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.43.csr
+    Width: 64
+    Index: 43
+    PseudoName: csr.43
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.44.csr
+    Width: 64
+    Index: 44
+    PseudoName: csr.44
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.45.csr
+    Width: 64
+    Index: 45
+    PseudoName: csr.45
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.46.csr
+    Width: 64
+    Index: 46
+    PseudoName: csr.46
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.47.csr
+    Width: 64
+    Index: 47
+    PseudoName: csr.47
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.48.csr
+    Width: 64
+    Index: 48
+    PseudoName: csr.48
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.49.csr
+    Width: 64
+    Index: 49
+    PseudoName: csr.49
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.50.csr
+    Width: 64
+    Index: 50
+    PseudoName: csr.50
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.51.csr
+    Width: 64
+    Index: 51
+    PseudoName: csr.51
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.52.csr
+    Width: 64
+    Index: 52
+    PseudoName: csr.52
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.53.csr
+    Width: 64
+    Index: 53
+    PseudoName: csr.53
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.54.csr
+    Width: 64
+    Index: 54
+    PseudoName: csr.54
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.55.csr
+    Width: 64
+    Index: 55
+    PseudoName: csr.55
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.56.csr
+    Width: 64
+    Index: 56
+    PseudoName: csr.56
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.57.csr
+    Width: 64
+    Index: 57
+    PseudoName: csr.57
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.58.csr
+    Width: 64
+    Index: 58
+    PseudoName: csr.58
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.59.csr
+    Width: 64
+    Index: 59
+    PseudoName: csr.59
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.60.csr
+    Width: 64
+    Index: 60
+    PseudoName: csr.60
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.61.csr
+    Width: 64
+    Index: 61
+    PseudoName: csr.61
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.62.csr
+    Width: 64
+    Index: 62
+    PseudoName: csr.62
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.63.csr
+    Width: 64
+    Index: 63
+    PseudoName: csr.63
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.64.csr
+    Width: 64
+    Index: 64
+    PseudoName: csr.64
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.65.csr
+    Width: 64
+    Index: 65
+    PseudoName: csr.65
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.66.csr
+    Width: 64
+    Index: 66
+    PseudoName: csr.66
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.67.csr
+    Width: 64
+    Index: 67
+    PseudoName: csr.67
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.68.csr
+    Width: 64
+    Index: 68
+    PseudoName: csr.68
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.69.csr
+    Width: 64
+    Index: 69
+    PseudoName: csr.69
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.70.csr
+    Width: 64
+    Index: 70
+    PseudoName: csr.70
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+  - RegName: TEST87.71.csr
+    Width: 64
+    Index: 71
+    PseudoName: csr.71
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: false
+    TUSReg: false
+    PCReg: false
+    Shared: false
+RegClasses:
+  - RegisterClassName: TEST87.regclass
+    Registers:
+      []
+  - RegisterClassName: TEST87.csrregclass
+    Registers:
+      - TEST87.0.csr
+      - TEST87.1.csr
+      - TEST87.2.csr
+      - TEST87.3.csr
+      - TEST87.4.csr
+      - TEST87.5.csr
+      - TEST87.6.csr
+      - TEST87.7.csr
+      - TEST87.8.csr
+      - TEST87.9.csr
+      - TEST87.10.csr
+      - TEST87.11.csr
+      - TEST87.12.csr
+      - TEST87.13.csr
+      - TEST87.14.csr
+      - TEST87.15.csr
+      - TEST87.16.csr
+      - TEST87.17.csr
+      - TEST87.18.csr
+      - TEST87.19.csr
+      - TEST87.20.csr
+      - TEST87.21.csr
+      - TEST87.22.csr
+      - TEST87.23.csr
+      - TEST87.24.csr
+      - TEST87.25.csr
+      - TEST87.26.csr
+      - TEST87.27.csr
+      - TEST87.28.csr
+      - TEST87.29.csr
+      - TEST87.30.csr
+      - TEST87.31.csr
+      - TEST87.32.csr
+      - TEST87.33.csr
+      - TEST87.34.csr
+      - TEST87.35.csr
+      - TEST87.36.csr
+      - TEST87.37.csr
+      - TEST87.38.csr
+      - TEST87.39.csr
+      - TEST87.40.csr
+      - TEST87.41.csr
+      - TEST87.42.csr
+      - TEST87.43.csr
+      - TEST87.44.csr
+      - TEST87.45.csr
+      - TEST87.46.csr
+      - TEST87.47.csr
+      - TEST87.48.csr
+      - TEST87.49.csr
+      - TEST87.50.csr
+      - TEST87.51.csr
+      - TEST87.52.csr
+      - TEST87.53.csr
+      - TEST87.54.csr
+      - TEST87.55.csr
+      - TEST87.56.csr
+      - TEST87.57.csr
+      - TEST87.58.csr
+      - TEST87.59.csr
+      - TEST87.60.csr
+      - TEST87.61.csr
+      - TEST87.62.csr
+      - TEST87.63.csr
+      - TEST87.64.csr
+      - TEST87.65.csr
+      - TEST87.66.csr
+      - TEST87.67.csr
+      - TEST87.68.csr
+      - TEST87.69.csr
+      - TEST87.70.csr
+      - TEST87.71.csr
+ISAs:
+  - ISAName: TEST87.isa
+InstFormats:
+  - InstFormatName: TEST87.if
+    ISA: TEST87.isa
+    FormatWidth: 32
+    Fields:
+      - FieldName: opcode
+        FieldType: CGInstCode
+        FieldWidth: 8
+        StartBit: 0
+        EndBit: 7
+        MandatoryField: true
+      - FieldName: RB
+        FieldType: CGInstReg
+        FieldWidth: 8
+        StartBit: 8
+        EndBit: 15
+        MandatoryField: false
+        RegClass: TEST87.regclass
+      - FieldName: RA
+        FieldType: CGInstReg
+        FieldWidth: 8
+        StartBit: 16
+        EndBit: 23
+        MandatoryField: false
+        RegClass: TEST87.regclass
+      - FieldName: RT
+        FieldType: CGInstReg
+        FieldWidth: 8
+        StartBit: 24
+        EndBit: 31
+        MandatoryField: false
+        RegClass: TEST87.csrregclass
+    Notes: The one and only inst format
+Insts:
+  - Inst: TEST87.inst0
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 1
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst0 %RT, %RA, %RB
+  - Inst: TEST87.inst1
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 2
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst1 %RT, %RA, %RB
+  - Inst: TEST87.inst2
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 3
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst2 %RT, %RA, %RB
+  - Inst: TEST87.inst3
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 4
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst3 %RT, %RA, %RB
+  - Inst: TEST87.inst4
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 5
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst4 %RT, %RA, %RB
+  - Inst: TEST87.inst5
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 6
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst5 %RT, %RA, %RB
+  - Inst: TEST87.inst6
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 7
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst6 %RT, %RA, %RB
+  - Inst: TEST87.inst7
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 8
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst7 %RT, %RA, %RB
+  - Inst: TEST87.inst8
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 9
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst8 %RT, %RA, %RB
+  - Inst: TEST87.inst9
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 10
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst9 %RT, %RA, %RB
+  - Inst: TEST87.inst10
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 11
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst10 %RT, %RA, %RB
+  - Inst: TEST87.inst11
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 12
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst11 %RT, %RA, %RB
+  - Inst: TEST87.inst12
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 13
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst12 %RT, %RA, %RB
+  - Inst: TEST87.inst13
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 14
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst13 %RT, %RA, %RB
+  - Inst: TEST87.inst14
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 15
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst14 %RT, %RA, %RB
+  - Inst: TEST87.inst15
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 16
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst15 %RT, %RA, %RB
+  - Inst: TEST87.inst16
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 17
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst16 %RT, %RA, %RB
+  - Inst: TEST87.inst17
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 18
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst17 %RT, %RA, %RB
+  - Inst: TEST87.inst18
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 19
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst18 %RT, %RA, %RB
+  - Inst: TEST87.inst19
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 20
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst19 %RT, %RA, %RB
+  - Inst: TEST87.inst20
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 21
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst20 %RT, %RA, %RB
+  - Inst: TEST87.inst21
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 22
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst21 %RT, %RA, %RB
+  - Inst: TEST87.inst22
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 23
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst22 %RT, %RA, %RB
+  - Inst: TEST87.inst23
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 24
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst23 %RT, %RA, %RB
+  - Inst: TEST87.inst24
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 25
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst24 %RT, %RA, %RB
+  - Inst: TEST87.inst25
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 26
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst25 %RT, %RA, %RB
+  - Inst: TEST87.inst26
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 27
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst26 %RT, %RA, %RB
+  - Inst: TEST87.inst27
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 28
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst27 %RT, %RA, %RB
+  - Inst: TEST87.inst28
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 29
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst28 %RT, %RA, %RB
+  - Inst: TEST87.inst29
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 30
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst29 %RT, %RA, %RB
+  - Inst: TEST87.inst30
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 31
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst30 %RT, %RA, %RB
+  - Inst: TEST87.inst31
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 32
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst31 %RT, %RA, %RB
+  - Inst: TEST87.inst32
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 33
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst32 %RT, %RA, %RB
+  - Inst: TEST87.inst33
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 34
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst33 %RT, %RA, %RB
+  - Inst: TEST87.inst34
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 35
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst34 %RT, %RA, %RB
+  - Inst: TEST87.inst35
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 36
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst35 %RT, %RA, %RB
+  - Inst: TEST87.inst36
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 37
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst36 %RT, %RA, %RB
+  - Inst: TEST87.inst37
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 38
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst37 %RT, %RA, %RB
+  - Inst: TEST87.inst38
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 39
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst38 %RT, %RA, %RB
+  - Inst: TEST87.inst39
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 40
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst39 %RT, %RA, %RB
+  - Inst: TEST87.inst40
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 41
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst40 %RT, %RA, %RB
+  - Inst: TEST87.inst41
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 42
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst41 %RT, %RA, %RB
+  - Inst: TEST87.inst42
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 43
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst42 %RT, %RA, %RB
+  - Inst: TEST87.inst43
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 44
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst43 %RT, %RA, %RB
+  - Inst: TEST87.inst44
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 45
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst44 %RT, %RA, %RB
+  - Inst: TEST87.inst45
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 46
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst45 %RT, %RA, %RB
+  - Inst: TEST87.inst46
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 47
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst46 %RT, %RA, %RB
+  - Inst: TEST87.inst47
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 48
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst47 %RT, %RA, %RB
+  - Inst: TEST87.inst48
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 49
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst48 %RT, %RA, %RB
+  - Inst: TEST87.inst49
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 50
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst49 %RT, %RA, %RB
+  - Inst: TEST87.inst50
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 51
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst50 %RT, %RA, %RB
+  - Inst: TEST87.inst51
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 52
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst51 %RT, %RA, %RB
+  - Inst: TEST87.inst52
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 53
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst52 %RT, %RA, %RB
+  - Inst: TEST87.inst53
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 54
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst53 %RT, %RA, %RB
+  - Inst: TEST87.inst54
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 55
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst54 %RT, %RA, %RB
+  - Inst: TEST87.inst55
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 56
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst55 %RT, %RA, %RB
+  - Inst: TEST87.inst56
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 57
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst56 %RT, %RA, %RB
+  - Inst: TEST87.inst57
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 58
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst57 %RT, %RA, %RB
+  - Inst: TEST87.inst58
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 59
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst58 %RT, %RA, %RB
+  - Inst: TEST87.inst59
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 60
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst59 %RT, %RA, %RB
+  - Inst: TEST87.inst60
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 61
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst60 %RT, %RA, %RB
+  - Inst: TEST87.inst61
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 62
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst61 %RT, %RA, %RB
+  - Inst: TEST87.inst62
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 63
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst62 %RT, %RA, %RB
+  - Inst: TEST87.inst63
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 64
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst63 %RT, %RA, %RB
+  - Inst: TEST87.inst64
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 65
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst64 %RT, %RA, %RB
+  - Inst: TEST87.inst65
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 66
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst65 %RT, %RA, %RB
+  - Inst: TEST87.inst66
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 67
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst66 %RT, %RA, %RB
+  - Inst: TEST87.inst67
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 68
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst67 %RT, %RA, %RB
+  - Inst: TEST87.inst68
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 69
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst68 %RT, %RA, %RB
+  - Inst: TEST87.inst69
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 70
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst69 %RT, %RA, %RB
+  - Inst: TEST87.inst70
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 71
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst70 %RT, %RA, %RB
+  - Inst: TEST87.inst71
+    ISA: TEST87.isa
+    InstFormat: TEST87.if
+    Encodings:
+      - EncodingField: opcode
+        EncodingWidth: 8
+        EncodingValue: 72
+    Impl: RT = RA + RB
+    Syntax: TEST87.inst71 %RT, %RA, %RB
+PseudoInsts:
+  - PseudoInst: TEST87.pinst0
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst1
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst2
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst3
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst4
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst5
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst6
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst7
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst8
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst9
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst10
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst11
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst12
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst13
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst14
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst15
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst16
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst17
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst18
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst19
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst20
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst21
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst22
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst23
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst24
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst25
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst26
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst27
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst28
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst29
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst30
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst31
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst32
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst33
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst34
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst35
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst36
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst37
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst38
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst39
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst40
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst41
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst42
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst43
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst44
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst45
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst46
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst47
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst48
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst49
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst50
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst51
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst52
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst53
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst54
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst55
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst56
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst57
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst58
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst59
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst60
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst61
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst62
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst63
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst64
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst65
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst66
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst67
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst68
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst69
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst70
+    Encodings:
+      []
+  - PseudoInst: TEST87.pinst71
+    Encodings:
+      []
+Caches:
+  - Cache: TEST87.L2.cache
+    Sets: 2
+    Ways: 8
+    LineSize: 128
+  - Cache: TEST87.core0.L1.cache
+    Sets: 1
+    Ways: 1
+    SubLevel: TEST87.L2.cache
+  - Cache: TEST87.core1.L1.cache
+    Sets: 1
+    Ways: 1
+    SubLevel: TEST87.L2.cache
+  - Cache: TEST87.core2.L1.cache
+    Sets: 1
+    Ways: 1
+    SubLevel: TEST87.L2.cache
+  - Cache: TEST87.core3.L1.cache
+    Sets: 1
+    Ways: 1
+    SubLevel: TEST87.L2.cache
+Comms:
+  - Comm: TEST87.comm
+    Type: NOC
+    Width: 64
+    Endpoints:
+      []
+Scratchpads:
+  - Scratchpad: TEST87.0.spad
+    MemSize: 1024
+    RqstPorts: 1
+    RspPorts: 1
+    StartAddr: 34359739392
+    Notes: scratchpad TEST87.0.spad
+  - Scratchpad: TEST87.1.spad
+    MemSize: 2048
+    RqstPorts: 1
+    RspPorts: 1
+    StartAddr: 34359740416
+    Notes: scratchpad TEST87.1.spad
+  - Scratchpad: TEST87.2.spad
+    MemSize: 3072
+    RqstPorts: 1
+    RspPorts: 1
+    StartAddr: 34359741440
+    Notes: scratchpad TEST87.2.spad
+  - Scratchpad: TEST87.3.spad
+    MemSize: 4096
+    RqstPorts: 1
+    RspPorts: 1
+    StartAddr: 34359742464
+    Notes: scratchpad TEST87.3.spad
+MemoryControllers:
+  - MemoryController: TEST87.0.mctrl
+    Ports: 2
+  - MemoryController: TEST87.1.mctrl
+    Ports: 2
+  - MemoryController: TEST87.2.mctrl
+    Ports: 2
+  - MemoryController: TEST87.3.mctrl
+    Ports: 2
+VTPControllers:
+  - VTP: TEST87.vtp
+Extensions:
+  - Extension: TEST87.ext0
+    Type: unknown
+    Registers:
+      - RegName: TEST87.ext0.reg
+        Width: 64
+        Index: 0
+        IsFixedValue: false
+        IsSIMD: false
+        RWReg: false
+        ROReg: false
+        CSRReg: true
+        AMSReg: false
+        TUSReg: false
+        PCReg: false
+        Shared: false
+    RegClasses:
+      - RegisterClassName: TEST87.ext0.regclass
+        Registers:
+          - TEST87.ext0.reg
+    ISAs:
+      - ISAName: TEST87.ext0.isa
+    RTL: when( RA === 0x05){RT = RA << RB}
+    RTLType: Verilog
+  - Extension: TEST87.ext1
+    Type: unknown
+    Registers:
+      - RegName: TEST87.ext1.reg
+        Width: 64
+        Index: 0
+        IsFixedValue: false
+        IsSIMD: false
+        RWReg: false
+        ROReg: false
+        CSRReg: true
+        AMSReg: false
+        TUSReg: false
+        PCReg: false
+        Shared: false
+    RegClasses:
+      - RegisterClassName: TEST87.ext1.regclass
+        Registers:
+          - TEST87.ext1.reg
+    ISAs:
+      - ISAName: TEST87.ext1.isa
+    RTL: when( RA === 0x05){RT = RA << RB}
+    RTLType: Verilog
+  - Extension: TEST87.ext2
+    Type: unknown
+    Registers:
+      - RegName: TEST87.ext2.reg
+        Width: 64
+        Index: 0
+        IsFixedValue: false
+        IsSIMD: false
+        RWReg: false
+        ROReg: false
+        CSRReg: true
+        AMSReg: false
+        TUSReg: false
+        PCReg: false
+        Shared: false
+    RegClasses:
+      - RegisterClassName: TEST87.ext2.regclass
+        Registers:
+          - TEST87.ext2.reg
+    ISAs:
+      - ISAName: TEST87.ext2.isa
+    RTL: when( RA === 0x05){RT = RA << RB}
+    RTLType: Verilog
+  - Extension: TEST87.ext3
+    Type: unknown
+    Registers:
+      - RegName: TEST87.ext3.reg
+        Width: 64
+        Index: 0
+        IsFixedValue: false
+        IsSIMD: false
+        RWReg: false
+        ROReg: false
+        CSRReg: true
+        AMSReg: false
+        TUSReg: false
+        PCReg: false
+        Shared: false
+    RegClasses:
+      - RegisterClassName: TEST87.ext3.regclass
+        Registers:
+          - TEST87.ext3.reg
+    ISAs:
+      - ISAName: TEST87.ext3.isa
+    RTL: when( RA === 0x05){RT = RA << RB}
+    RTLType: Verilog
+Cores:
+  - Core: TEST87.core0
+    ThreadUnits: 1
+    Cache: TEST87.core0.L1.cache
+    RegisterClasses:
+      - RegClass: TEST87.regclass
+      - RegClass: TEST87.csrregclass
+    Extensions:
+      - Extension: TEST87.ext0
+  - Core: TEST87.core1
+    ThreadUnits: 2
+    Cache: TEST87.core1.L1.cache
+    RegisterClasses:
+      - RegClass: TEST87.regclass
+      - RegClass: TEST87.csrregclass
+    Extensions:
+      - Extension: TEST87.ext1
+  - Core: TEST87.core2
+    ThreadUnits: 3
+    Cache: TEST87.core2.L1.cache
+    RegisterClasses:
+      - RegClass: TEST87.regclass
+      - RegClass: TEST87.csrregclass
+    Extensions:
+      - Extension: TEST87.ext2
+  - Core: TEST87.core3
+    ThreadUnits: 4
+    Cache: TEST87.core3.L1.cache
+    RegisterClasses:
+      - RegClass: TEST87.regclass
+      - RegClass: TEST87.csrregclass
+    Extensions:
+      - Extension: TEST87.ext3
+Socs:
+  - Soc: TEST87.soc

--- a/test/Yaml/Reader/yaml_reader_test_95.cpp
+++ b/test/Yaml/Reader/yaml_reader_test_95.cpp
@@ -1,0 +1,37 @@
+//
+// _YAML_READER_TEST95_CPP_
+//
+// Copyright (C) 2017-2020 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+//
+
+#include <iostream>
+#include "CoreGen/CoreGenBackend/CoreGenBackend.h"
+
+std::string PROJNAME = "BasicRISC";
+std::string PROJROOT = "./";
+std::string ARCHROOT = "./";
+std::string PROJYAML = "../TEST95.yaml";
+
+int main( int argc, char **argv ){
+  CoreGenBackend *CG = new CoreGenBackend(PROJNAME,
+                                          PROJROOT,
+                                          ARCHROOT);
+  if( !CG ){
+    std::cout << "ERROR : FAILED TO CREATE COREGEN OBJECT" << std::endl;
+    return -1;
+  }
+
+  if( !CG->ReadIR( PROJYAML ) ){
+    std::cout << "ERROR : FAILED TO READ YAML IR:" << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  delete CG;
+  return 0;
+}


### PR DESCRIPTION
adding cache line size parameter that defaults to 64 bytes; fix for Issue #89; This requires IR Spec 1.4.5 and beyond