### PR TITLE
Adding metadata support for pipeline stage definitions

### DIFF
--- a/include/CoreGen/CoreGenSigMap/SCSig.h
+++ b/include/CoreGen/CoreGenSigMap/SCSig.h
@@ -121,6 +121,7 @@ private:
   signed DistanceFalse;     ///< SCSig: Branch distance (in uOps) for alternate targets
   std::string Inst;         ///< SCSig: Name of the instruction
   std::string Name;         ///< SCSig: Name of the signal
+  std::string PipeName;     ///< SCSIg: Name of the respective pipeline stage
   std::vector<std::string> Inputs; ///< SCSig: vector of required inputs for ALU ops
 
 public:
@@ -131,7 +132,7 @@ public:
   SCSig(SigType T, unsigned W);
 
   /// Overloaded constructor
-  SCSig(SigType T, unsigned W, std::string I);
+  SCSig(SigType T, unsigned W, std::string I, std::string P);
 
   /// Overload constructor
   SCSig(SigType T, std::string I);
@@ -140,13 +141,13 @@ public:
   SCSig(SigType T, std::string I, std::string N);
 
   /// Overloaded constructor
-  SCSig(SigType T, unsigned W, signed DT, signed DF, std::string I);
+  SCSig(SigType T, unsigned W, signed DT, signed DF, std::string I, std::string P);
 
   /// Overloaded constructor
-  SCSig(SigType T, unsigned W, std::string I, std::string N);
+  SCSig(SigType T, unsigned W, std::string I, std::string N, std::string P);
 
   /// Overloaded constructor
-  SCSig(SigType T, unsigned W, signed DT, signed DF, std::string I, std::string N );
+  SCSig(SigType T, unsigned W, signed DT, signed DF, std::string I, std::string N, std::string P );
 
   /// Default destructor
   ~SCSig();
@@ -210,6 +211,15 @@ public:
 
   /// Sets the signal name
   bool SetName( std::string Name );
+
+  /// Determines whether there is a specific pipe stage defined
+  bool IsPipeDefined();
+
+  /// Retrieves the pipeline name
+  std::string GetPipeName() { return PipeName; }
+
+  /// Sets the pipeline name
+  bool SetPipeName( std::string PName );
 
   /// Retrieves the signal name
   std::string GetName() { return Name; }

--- a/include/CoreGen/StoneCutter/Passes/SCSigMap.h
+++ b/include/CoreGen/StoneCutter/Passes/SCSigMap.h
@@ -42,7 +42,7 @@ private:
   std::vector<SCIntrin *>* Intrins; ///< Intrinsics vector
 
   // Private functions
-  /// walks the LLVM Module object and discovers all the interior signals
+  /// Walks the LLVM Module object and discovers all the interior signals
   bool DiscoverSigMap();
 
   /// Decodes an individual instruction for the signal map

--- a/include/CoreGen/StoneCutter/SCIntrin.h
+++ b/include/CoreGen/StoneCutter/SCIntrin.h
@@ -77,7 +77,11 @@ public:
   /// Generates the intrinsic signal map
   virtual bool GetSigMap(CoreGenSigMap *Sigs,Instruction &I,std::string Inst){
     for( auto i : ISignals ){
-      Sigs->InsertSignal(new SCSig(i->GetType(), i->GetWidth(), Inst));
+      std::string Str;
+      if( MDNode *N = I.getMetadata("pipe.pipeName")) {
+        Str = cast<MDString>(N->getOperand(0))->getString().str();
+      }
+      Sigs->InsertSignal(new SCSig(i->GetType(), i->GetWidth(), Inst, Str));
     }
     return true;
   }

--- a/include/CoreGen/StoneCutter/SCPass.h
+++ b/include/CoreGen/StoneCutter/SCPass.h
@@ -104,6 +104,9 @@ public:
   /// Determines if the target variable has the target attribute
   bool HasGlobalAttribute(std::string Var, std::string Attribute );
 
+  /// Retrieves a metadata pipeName instance from the target instruction
+  std::string GetMDPipeName(Instruction &I);
+
   /// Retrieves the target attribute from the target global variable
   std::string GetGlobalAttribute(std::string Var, std::string Attribute);
 

--- a/src/CoreGenSigMap/CoreGenSigMap.cpp
+++ b/src/CoreGenSigMap/CoreGenSigMap.cpp
@@ -347,12 +347,17 @@ bool CoreGenSigMap::ReadInstSignals(const YAML::Node& InstNodes){
           DF = LSNode["DistanceFalse"].as<signed>();
         }
 
+        std::string PipeStage;
+        if( CheckValidNode(LSNode,"PipeStage") ){
+          PipeStage = LSNode["PipeStage"].as<std::string>();
+        }
+
         std::string FusedOp;
         if( CheckValidNode(LSNode,"FusedOp") ){
           FusedOp = LSNode["FusedOp"].as<std::string>();
         }
 
-        Signals.push_back(new SCSig(Type,Width,DT,DF,Name,SigName));
+        Signals.push_back(new SCSig(Type,Width,DT,DF,Name,SigName,PipeStage));
         if( FusedOp.length() > 0 ){
           // write the fused op to the latest signal
           FusedOpType FType = StrToFusedOpType(FusedOp);
@@ -531,6 +536,9 @@ bool CoreGenSigMap::WriteInstSignals(YAML::Emitter *out){
       *out << YAML::Key << "Width" << YAML::Value << CSigs[j]->GetWidth();
       *out << YAML::Key << "DistanceTrue" << YAML::Value << CSigs[j]->GetDistanceTrue();
       *out << YAML::Key << "DistanceFalse" << YAML::Value << CSigs[j]->GetDistanceFalse();
+      if( CSigs[j]->IsPipeDefined() ){
+        *out << YAML::Key << "PipeStage" << YAML::Value << CSigs[j]->GetPipeName();
+      }
       if( CSigs[j]->GetFusedType() != FOP_UNK )
         *out << YAML::Key << "FusedOp" << YAML::Value << CSigs[j]->FusedOpTypeToStr();
 

--- a/src/CoreGenSigMap/SCSig.cpp
+++ b/src/CoreGenSigMap/SCSig.cpp
@@ -26,9 +26,9 @@ SCSig::SCSig(SigType T,std::string I)
   Name = this->SigTypeToStr();
 }
 
-SCSig::SCSig(SigType T,unsigned W,std::string I)
+SCSig::SCSig(SigType T,unsigned W,std::string I,std::string P)
   : Type(T), FType(FOP_UNK), SigWidth(W),
-    DistanceTrue(0), DistanceFalse(0), Inst(I){
+    DistanceTrue(0), DistanceFalse(0), Inst(I),PipeName(P){
   Name = this->SigTypeToStr();
 }
 
@@ -37,21 +37,21 @@ SCSig::SCSig(SigType T,std::string I,std::string N)
     DistanceTrue(0), DistanceFalse(0), Inst(I), Name(N){
 }
 
-SCSig::SCSig(SigType T,unsigned W,signed DT,signed DF,std::string I)
+SCSig::SCSig(SigType T,unsigned W,signed DT,signed DF,std::string I,std::string P)
   : Type(T), FType(FOP_UNK), SigWidth(W),
-    DistanceTrue(DT), DistanceFalse(DF), Inst(I){
+    DistanceTrue(DT), DistanceFalse(DF), Inst(I), PipeName(P){
   Name = this->SigTypeToStr();
 }
 
-SCSig::SCSig(SigType T,unsigned W,std::string I,std::string N)
+SCSig::SCSig(SigType T,unsigned W,std::string I,std::string N,std::string P)
   : Type(T), FType(FOP_UNK), SigWidth(W),
-    DistanceTrue(0), DistanceFalse(0), Inst(I), Name(N){
+    DistanceTrue(0), DistanceFalse(0), Inst(I), Name(N), PipeName(P){
 }
 
 SCSig::SCSig(SigType T,unsigned W,signed DT,signed DF,
-             std::string I,std::string N)
+             std::string I,std::string N,std::string P)
   : Type(T), FType(FOP_UNK), SigWidth(W),
-    DistanceTrue(DT), DistanceFalse(DF), Inst(I), Name(N){
+    DistanceTrue(DT), DistanceFalse(DF), Inst(I), Name(N), PipeName(P){
 }
 
 SCSig::~SCSig(){
@@ -163,6 +163,17 @@ bool SCSig::SetType( SigType T ){
 
 bool SCSig::SetWidth( unsigned W ){
   SigWidth = W;
+  return true;
+}
+
+bool SCSig::IsPipeDefined(){
+  if( PipeName.length() > 0 )
+    return true;
+  return false;
+}
+
+bool SCSig::SetPipeName( std::string PName ){
+  PipeName = PName;
   return true;
 }
 

--- a/src/StoneCutter/Intrinsics/SCLoad.cpp
+++ b/src/StoneCutter/Intrinsics/SCLoad.cpp
@@ -27,7 +27,11 @@ bool SCLoad::GetSigMap(CoreGenSigMap *Sigs,
                        Instruction &I,
                        std::string Inst){
   unsigned width = I.getOperand(0)->getType()->getIntegerBitWidth();
-  return Sigs->InsertSignal(new SCSig(MEM_READ,width,Inst) );
+  std::string Str;
+  if( MDNode *N = I.getMetadata("pipe.pipeName")) {
+    Str = cast<MDString>(N->getOperand(0))->getString().str();
+  }
+  return Sigs->InsertSignal(new SCSig(MEM_READ,width,Inst,Str) );
 }
 
 // EOF

--- a/src/StoneCutter/Intrinsics/SCLoadElem.cpp
+++ b/src/StoneCutter/Intrinsics/SCLoadElem.cpp
@@ -33,7 +33,12 @@ bool SCLoadElem::GetSigMap(CoreGenSigMap *Sigs,
     width = I.getOperand(1)->getType()->getIntegerBitWidth();
   }
 
-  return Sigs->InsertSignal(new SCSig(MEM_READ,width,Inst) );
+  std::string Str;
+  if( MDNode *N = I.getMetadata("pipe.pipeName")) {
+    Str = cast<MDString>(N->getOperand(0))->getString().str();
+  }
+
+  return Sigs->InsertSignal(new SCSig(MEM_READ,width,Inst,Str) );
 }
 
 // EOF

--- a/src/StoneCutter/Intrinsics/SCStore.cpp
+++ b/src/StoneCutter/Intrinsics/SCStore.cpp
@@ -27,7 +27,11 @@ bool SCStore::GetSigMap(CoreGenSigMap *Sigs,
                         Instruction &I,
                         std::string Inst){
   unsigned width = I.getOperand(0)->getType()->getIntegerBitWidth();
-  return Sigs->InsertSignal(new SCSig(MEM_WRITE,width,Inst) );
+  std::string Str;
+  if( MDNode *N = I.getMetadata("pipe.pipeName")) {
+    Str = cast<MDString>(N->getOperand(0))->getString().str();
+  }
+  return Sigs->InsertSignal(new SCSig(MEM_WRITE,width,Inst,Str) );
 }
 
 // EOF

--- a/src/StoneCutter/Intrinsics/SCStoreElem.cpp
+++ b/src/StoneCutter/Intrinsics/SCStoreElem.cpp
@@ -33,7 +33,12 @@ bool SCStoreElem::GetSigMap(CoreGenSigMap *Sigs,
     width = I.getOperand(2)->getType()->getIntegerBitWidth();
   }
 
-  return Sigs->InsertSignal(new SCSig(MEM_WRITE,width,Inst) );
+  std::string Str;
+  if( MDNode *N = I.getMetadata("pipe.pipeName")) {
+    Str = cast<MDString>(N->getOperand(0))->getString().str();
+  }
+
+  return Sigs->InsertSignal(new SCSig(MEM_WRITE,width,Inst,Str) );
 }
 
 // EOF

--- a/src/StoneCutter/SCPass.cpp
+++ b/src/StoneCutter/SCPass.cpp
@@ -354,6 +354,13 @@ std::string SCPass::StrToUpper(std::string S){
   return S;
 }
 
+std::string SCPass::GetMDPipeName(Instruction &I){
+  std::string Str;
+  if( MDNode *N = I.getMetadata("pipe.pipeName")) {
+    Str = cast<MDString>(N->getOperand(0))->getString().str();
+  }
+  return Str;
+}
 
 std::string SCPass::TraceOperand( Function &F, Value *V,
                                   bool &isPredef, bool &isImm,

--- a/test/StoneCutter/SCSigV/KnownPass/sc_sigv_test6.yaml
+++ b/test/StoneCutter/SCSigV/KnownPass/sc_sigv_test6.yaml
@@ -1,0 +1,1655 @@
+SignalTop:
+  - Signal: ALUTMP0_64_READ
+  - Signal: ALUTMP0_64_WRITE
+  - Signal: ALUTMP1_64_READ
+  - Signal: ALUTMP1_64_WRITE
+  - Signal: ALUTMP2_64_WRITE
+  - Signal: ALU_ADD
+  - Signal: ALU_AND
+  - Signal: ALU_DIV
+  - Signal: ALU_MUL
+  - Signal: ALU_OR
+  - Signal: ALU_SLL
+  - Signal: ALU_SRL
+  - Signal: ALU_SUB
+  - Signal: ALU_XOR
+  - Signal: MEM_READ
+  - Signal: MEM_WRITE
+  - Signal: MUX
+  - Signal: MUX_EQ
+  - Signal: MUX_GTU
+  - Signal: MUX_LTU
+  - Signal: PC_BRJMP
+  - Signal: PC_INCR
+  - Signal: imm_READ
+  - Signal: pc_CTRL_READ
+  - Signal: pc_CTRL_WRITE
+  - Signal: ra_GPR_READ
+  - Signal: rb_GPR_READ
+  - Signal: rt_GPR_READ
+  - Signal: rt_GPR_WRITE
+Instructions:
+  - Inst: add
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        PipeStage: p0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        PipeStage: p0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        PipeStage: p0
+        Inputs:
+          - Input: rb_GPR
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+        PipeStage: p0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: and
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_AND
+        Type: ALU_AND
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: rb_GPR
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: br
+    Signals:
+      - Signal: pc_CTRL_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: rt_GPR
+            Input: pc_CTRL
+      - Signal: pc_CTRL_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_BRJMP
+        Type: PC_BRJMP
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: bra
+    Signals:
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: pc_CTRL_WRITE
+        Type: REG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_BRJMP
+        Type: PC_BRJMP
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: brac
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX_EQ
+        Type: MUX_EQ
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: pc_CTRL_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: pc_CTRL
+            Input: 4
+      - Signal: pc_CTRL_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX
+        Type: MUX
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: pc_CTRL_WRITE
+        Type: REG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_BRJMP
+        Type: PC_BRJMP
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: brc
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX_EQ
+        Type: MUX_EQ
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: pc_CTRL_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: rt_GPR
+            Input: pc_CTRL
+      - Signal: pc_CTRL_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: pc_CTRL
+            Input: 4
+      - Signal: pc_CTRL_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX
+        Type: MUX
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: pc_CTRL_WRITE
+        Type: REG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_BRJMP
+        Type: PC_BRJMP
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: cadd
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: rb_GPR
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: cmp.eq
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX_EQ
+        Type: MUX_EQ
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX
+        Type: MUX
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: cmp.gt
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX_GTU
+        Type: MUX_GTU
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX
+        Type: MUX
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: cmp.gte
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX_LTU
+        Type: MUX_LTU
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX
+        Type: MUX
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: cmp.lt
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX_LTU
+        Type: MUX_LTU
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX
+        Type: MUX
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: cmp.lte
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX_GTU
+        Type: MUX_GTU
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX
+        Type: MUX
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: cmp.ne
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX_EQ
+        Type: MUX_EQ
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX
+        Type: MUX
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: div
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_DIV
+        Type: ALU_DIV
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: ra_GPR
+            Input: rb_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: divu
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_DIV
+        Type: ALU_DIV
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: ra_GPR
+            Input: rb_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: ladd
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: rb_GPR
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: lb
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: imm_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: imm
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MEM_READ
+        Type: MEM_READ
+        Width: 8
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+        FusedOp: FOP_SEXT
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: lbu
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: imm_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: imm
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MEM_READ
+        Type: MEM_READ
+        Width: 8
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+        FusedOp: FOP_ZEXT
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: ld
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: imm_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: imm
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MEM_READ
+        Type: MEM_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: lh
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: imm_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: imm
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MEM_READ
+        Type: MEM_READ
+        Width: 16
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+        FusedOp: FOP_SEXT
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: lhu
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: imm_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: imm
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MEM_READ
+        Type: MEM_READ
+        Width: 16
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+        FusedOp: FOP_ZEXT
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: lw
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: imm_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: imm
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MEM_READ
+        Type: MEM_READ
+        Width: 32
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+        FusedOp: FOP_SEXT
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: lwu
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: imm_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: imm
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MEM_READ
+        Type: MEM_READ
+        Width: 32
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+        FusedOp: FOP_ZEXT
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: mul
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_MUL
+        Type: ALU_MUL
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: rb_GPR
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: nand
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_AND
+        Type: ALU_AND
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: rb_GPR
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+        FusedOp: FOP_NOT
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: nor
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_OR
+        Type: ALU_OR
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: rb_GPR
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+        FusedOp: FOP_NOT
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: not
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        FusedOp: FOP_NOT
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: or
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_OR
+        Type: ALU_OR
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: rb_GPR
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: sb
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: imm_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: imm
+            Input: rt_GPR
+      - Signal: ALUTMP0_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP0_64_READ
+        Type: AREG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MEM_WRITE
+        Type: MEM_WRITE
+        Width: 8
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP1_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: sbu
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        FusedOp: FOP_ZEXT
+      - Signal: ALUTMP1_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: imm_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: imm
+            Input: rt_GPR
+      - Signal: ALUTMP0_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP1_64_READ
+        Type: AREG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP0_64_READ
+        Type: AREG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MEM_WRITE
+        Type: MEM_WRITE
+        Width: 8
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP2_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: sd
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: imm_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: imm
+            Input: rt_GPR
+      - Signal: ALUTMP0_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP0_64_READ
+        Type: AREG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MEM_WRITE
+        Type: MEM_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP1_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: sh
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        FusedOp: FOP_SEXT
+      - Signal: ALUTMP1_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: imm_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: imm
+            Input: rt_GPR
+      - Signal: ALUTMP0_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP1_64_READ
+        Type: AREG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP0_64_READ
+        Type: AREG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MEM_WRITE
+        Type: MEM_WRITE
+        Width: 16
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP2_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: shu
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        FusedOp: FOP_ZEXT
+      - Signal: ALUTMP1_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: imm_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: imm
+            Input: rt_GPR
+      - Signal: ALUTMP0_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP1_64_READ
+        Type: AREG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP0_64_READ
+        Type: AREG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MEM_WRITE
+        Type: MEM_WRITE
+        Width: 16
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP2_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: sll
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_SLL
+        Type: ALU_SLL
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: ra_GPR
+            Input: rb_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: sra
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_SRL
+        Type: ALU_SRL
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: ra_GPR
+            Input: rb_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: srl
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_SRL
+        Type: ALU_SRL
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: ra_GPR
+            Input: rb_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: sub
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        PipeStage: p0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        PipeStage: p0
+      - Signal: ALU_SUB
+        Type: ALU_SUB
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        PipeStage: p0
+        Inputs:
+          - Input: ra_GPR
+            Input: rb_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+        PipeStage: p0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: sw
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        FusedOp: FOP_SEXT
+      - Signal: ALUTMP1_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: imm_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: imm
+            Input: rt_GPR
+      - Signal: ALUTMP0_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP1_64_READ
+        Type: AREG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP0_64_READ
+        Type: AREG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MEM_WRITE
+        Type: MEM_WRITE
+        Width: 32
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP2_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: swu
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        FusedOp: FOP_ZEXT
+      - Signal: ALUTMP1_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: imm_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: imm
+            Input: rt_GPR
+      - Signal: ALUTMP0_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP1_64_READ
+        Type: AREG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP0_64_READ
+        Type: AREG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MEM_WRITE
+        Type: MEM_WRITE
+        Width: 32
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP2_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: xor
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_XOR
+        Type: ALU_XOR
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: rb_GPR
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+Temps:
+  - Temp: ALUTMP0_64
+    Width: 64
+    Mappings:
+      - Map: sb
+        IRName: addtmp
+      - Map: sh
+        IRName: addtmp
+      - Map: sw
+        IRName: addtmp
+      - Map: sd
+        IRName: addtmp
+      - Map: sbu
+        IRName: addtmp
+      - Map: shu
+        IRName: addtmp
+      - Map: swu
+        IRName: addtmp
+  - Temp: ALUTMP1_64
+    Width: 64
+    Mappings:
+      - Map: sb
+        IRName: calltmp
+      - Map: sh
+        IRName: calltmp
+      - Map: sw
+        IRName: calltmp
+      - Map: sd
+        IRName: calltmp
+      - Map: sbu
+        IRName: calltmp
+      - Map: shu
+        IRName: calltmp
+      - Map: swu
+        IRName: calltmp
+  - Temp: ALUTMP2_64
+    Width: 64
+    Mappings:
+      - Map: sh
+        IRName: calltmp1
+      - Map: sw
+        IRName: calltmp1
+      - Map: sbu
+        IRName: calltmp1
+      - Map: shu
+        IRName: calltmp1
+      - Map: swu
+        IRName: calltmp1

--- a/test/StoneCutter/SCSigV/KnownPass/sc_sigv_test7.yaml
+++ b/test/StoneCutter/SCSigV/KnownPass/sc_sigv_test7.yaml
@@ -1,0 +1,1655 @@
+SignalTop:
+  - Signal: ALUTMP0_64_READ
+  - Signal: ALUTMP0_64_WRITE
+  - Signal: ALUTMP1_64_READ
+  - Signal: ALUTMP1_64_WRITE
+  - Signal: ALUTMP2_64_WRITE
+  - Signal: ALU_ADD
+  - Signal: ALU_AND
+  - Signal: ALU_DIV
+  - Signal: ALU_MUL
+  - Signal: ALU_OR
+  - Signal: ALU_SLL
+  - Signal: ALU_SRL
+  - Signal: ALU_SUB
+  - Signal: ALU_XOR
+  - Signal: MEM_READ
+  - Signal: MEM_WRITE
+  - Signal: MUX
+  - Signal: MUX_EQ
+  - Signal: MUX_GTU
+  - Signal: MUX_LTU
+  - Signal: PC_BRJMP
+  - Signal: PC_INCR
+  - Signal: imm_READ
+  - Signal: pc_CTRL_READ
+  - Signal: pc_CTRL_WRITE
+  - Signal: ra_GPR_READ
+  - Signal: rb_GPR_READ
+  - Signal: rt_GPR_READ
+  - Signal: rt_GPR_WRITE
+Instructions:
+  - Inst: add
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        PipeStage: p0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        PipeStage: p0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        PipeStage: p0
+        Inputs:
+          - Input: rb_GPR
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+        PipeStage: p0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: and
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_AND
+        Type: ALU_AND
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: rb_GPR
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: br
+    Signals:
+      - Signal: pc_CTRL_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: rt_GPR
+            Input: pc_CTRL
+      - Signal: pc_CTRL_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_BRJMP
+        Type: PC_BRJMP
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: bra
+    Signals:
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: pc_CTRL_WRITE
+        Type: REG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_BRJMP
+        Type: PC_BRJMP
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: brac
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX_EQ
+        Type: MUX_EQ
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: pc_CTRL_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: pc_CTRL
+            Input: 4
+      - Signal: pc_CTRL_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX
+        Type: MUX
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: pc_CTRL_WRITE
+        Type: REG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_BRJMP
+        Type: PC_BRJMP
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: brc
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX_EQ
+        Type: MUX_EQ
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: pc_CTRL_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: rt_GPR
+            Input: pc_CTRL
+      - Signal: pc_CTRL_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: pc_CTRL
+            Input: 4
+      - Signal: pc_CTRL_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX
+        Type: MUX
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: pc_CTRL_WRITE
+        Type: REG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_BRJMP
+        Type: PC_BRJMP
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: cadd
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: rb_GPR
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: cmp.eq
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX_EQ
+        Type: MUX_EQ
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX
+        Type: MUX
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: cmp.gt
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX_GTU
+        Type: MUX_GTU
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX
+        Type: MUX
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: cmp.gte
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX_LTU
+        Type: MUX_LTU
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX
+        Type: MUX
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: cmp.lt
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX_LTU
+        Type: MUX_LTU
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX
+        Type: MUX
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: cmp.lte
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX_GTU
+        Type: MUX_GTU
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX
+        Type: MUX
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: cmp.ne
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX_EQ
+        Type: MUX_EQ
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MUX
+        Type: MUX
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: div
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_DIV
+        Type: ALU_DIV
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: ra_GPR
+            Input: rb_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: divu
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_DIV
+        Type: ALU_DIV
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: ra_GPR
+            Input: rb_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: ladd
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: rb_GPR
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: lb
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: imm_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: imm
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MEM_READ
+        Type: MEM_READ
+        Width: 8
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+        FusedOp: FOP_SEXT
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: lbu
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: imm_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: imm
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MEM_READ
+        Type: MEM_READ
+        Width: 8
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+        FusedOp: FOP_ZEXT
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: ld
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: imm_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: imm
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MEM_READ
+        Type: MEM_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: lh
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: imm_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: imm
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MEM_READ
+        Type: MEM_READ
+        Width: 16
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+        FusedOp: FOP_SEXT
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: lhu
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: imm_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: imm
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MEM_READ
+        Type: MEM_READ
+        Width: 16
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+        FusedOp: FOP_ZEXT
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: lw
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: imm_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: imm
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MEM_READ
+        Type: MEM_READ
+        Width: 32
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+        FusedOp: FOP_SEXT
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: lwu
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: imm_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: imm
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MEM_READ
+        Type: MEM_READ
+        Width: 32
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+        FusedOp: FOP_ZEXT
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: mul
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_MUL
+        Type: ALU_MUL
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: rb_GPR
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: nand
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_AND
+        Type: ALU_AND
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: rb_GPR
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+        FusedOp: FOP_NOT
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: nor
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_OR
+        Type: ALU_OR
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: rb_GPR
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+        FusedOp: FOP_NOT
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: not
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        FusedOp: FOP_NOT
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: or
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_OR
+        Type: ALU_OR
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: rb_GPR
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: sb
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: imm_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: imm
+            Input: rt_GPR
+      - Signal: ALUTMP0_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP0_64_READ
+        Type: AREG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MEM_WRITE
+        Type: MEM_WRITE
+        Width: 8
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP1_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: sbu
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        FusedOp: FOP_ZEXT
+      - Signal: ALUTMP1_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: imm_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: imm
+            Input: rt_GPR
+      - Signal: ALUTMP0_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP1_64_READ
+        Type: AREG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP0_64_READ
+        Type: AREG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MEM_WRITE
+        Type: MEM_WRITE
+        Width: 8
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP2_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: sd
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: imm_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: imm
+            Input: rt_GPR
+      - Signal: ALUTMP0_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP0_64_READ
+        Type: AREG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MEM_WRITE
+        Type: MEM_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP1_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: sh
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        FusedOp: FOP_SEXT
+      - Signal: ALUTMP1_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: imm_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: imm
+            Input: rt_GPR
+      - Signal: ALUTMP0_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP1_64_READ
+        Type: AREG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP0_64_READ
+        Type: AREG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MEM_WRITE
+        Type: MEM_WRITE
+        Width: 16
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP2_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: shu
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        FusedOp: FOP_ZEXT
+      - Signal: ALUTMP1_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: imm_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: imm
+            Input: rt_GPR
+      - Signal: ALUTMP0_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP1_64_READ
+        Type: AREG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP0_64_READ
+        Type: AREG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MEM_WRITE
+        Type: MEM_WRITE
+        Width: 16
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP2_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: sll
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_SLL
+        Type: ALU_SLL
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: ra_GPR
+            Input: rb_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: sra
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_SRL
+        Type: ALU_SRL
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: ra_GPR
+            Input: rb_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: srl
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_SRL
+        Type: ALU_SRL
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: ra_GPR
+            Input: rb_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: sub
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        PipeStage: p1
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        PipeStage: p3
+      - Signal: ALU_SUB
+        Type: ALU_SUB
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        PipeStage: p0
+        Inputs:
+          - Input: ra_GPR
+            Input: rb_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+        PipeStage: p0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: sw
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        FusedOp: FOP_SEXT
+      - Signal: ALUTMP1_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: imm_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: imm
+            Input: rt_GPR
+      - Signal: ALUTMP0_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP1_64_READ
+        Type: AREG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP0_64_READ
+        Type: AREG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MEM_WRITE
+        Type: MEM_WRITE
+        Width: 32
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP2_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: swu
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        FusedOp: FOP_ZEXT
+      - Signal: ALUTMP1_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rt_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: imm_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_ADD
+        Type: ALU_ADD
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: imm
+            Input: rt_GPR
+      - Signal: ALUTMP0_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP1_64_READ
+        Type: AREG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP0_64_READ
+        Type: AREG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: MEM_WRITE
+        Type: MEM_WRITE
+        Width: 32
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALUTMP2_64_WRITE
+        Type: AREG_WRITE
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+  - Inst: xor
+    Signals:
+      - Signal: ra_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: rb_GPR_READ
+        Type: REG_READ
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: ALU_XOR
+        Type: ALU_XOR
+        Width: 64
+        DistanceTrue: 0
+        DistanceFalse: 0
+        Inputs:
+          - Input: rb_GPR
+            Input: ra_GPR
+      - Signal: rt_GPR_WRITE
+        Type: REG_WRITE
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+      - Signal: PC_INCR
+        Type: PC_INCR
+        Width: 1
+        DistanceTrue: 0
+        DistanceFalse: 0
+Temps:
+  - Temp: ALUTMP0_64
+    Width: 64
+    Mappings:
+      - Map: sb
+        IRName: addtmp
+      - Map: sh
+        IRName: addtmp
+      - Map: sw
+        IRName: addtmp
+      - Map: sd
+        IRName: addtmp
+      - Map: sbu
+        IRName: addtmp
+      - Map: shu
+        IRName: addtmp
+      - Map: swu
+        IRName: addtmp
+  - Temp: ALUTMP1_64
+    Width: 64
+    Mappings:
+      - Map: sb
+        IRName: calltmp
+      - Map: sh
+        IRName: calltmp
+      - Map: sw
+        IRName: calltmp
+      - Map: sd
+        IRName: calltmp
+      - Map: sbu
+        IRName: calltmp
+      - Map: shu
+        IRName: calltmp
+      - Map: swu
+        IRName: calltmp
+  - Temp: ALUTMP2_64
+    Width: 64
+    Mappings:
+      - Map: sh
+        IRName: calltmp1
+      - Map: sw
+        IRName: calltmp1
+      - Map: sbu
+        IRName: calltmp1
+      - Map: shu
+        IRName: calltmp1
+      - Map: swu
+        IRName: calltmp1

--- a/test/StoneCutter/SigMap/sc_sigmap_test9.sc
+++ b/test/StoneCutter/SigMap/sc_sigmap_test9.sc
@@ -1,0 +1,258 @@
+#-- StoneCutter source file for ISA=BasicRISC.ISA
+
+
+# Instruction Formats
+instformat Arith.if(reg[GPR] ra,reg[GPR] rb,reg[GPR] rt,enc opc,enc func,imm imm)
+instformat ReadCtrl.if(reg[GPR] ra,reg[CTRL] rb,reg[GPR] rt,enc opc,enc func,imm imm)
+instformat WriteCtrl.if(reg[GPR] ra,reg[GPR] rb,reg[CTRL] rt,enc opc,enc func,imm imm)
+
+# Register Class Definitions
+regclass GPR( u64 r0, u64 r1, u64 r2, u64 r3, u64 r4, u64 r5, u64 r6, u64 r7, u64 r8, u64 r9, u64 r10, u64 r11, u64 r12, u64 r13, u64 r14, u64 r15, u64 r16, u64 r17, u64 r18, u64 r19, u64 r20, u64 r21, u64 r22, u64 r23, u64 r24, u64 r25, u64 r26, u64 r27, u64 r28, u64 r29, u64 r30, u64 r31 )
+regclass CTRL( u64 pc[PC], u64 exc, u64 ne, u64 eq, u64 gt, u64 lt, u64 gte, u64 lte, u64 sp, u64 fp, u64 rp )
+
+
+# Instruction Definitions
+# add
+def add:Arith.if( ra rb rt imm )
+{
+  pipe p0 {
+    rt = ra + rb
+  }
+}
+
+# sub
+def sub:Arith.if( ra rb rt imm )
+{
+  pipe p0 {
+    rt = ra - rb
+  }
+}
+
+# mul
+def mul:Arith.if( ra rb rt imm )
+{
+rt = ra * rb
+}
+
+# div
+def div:Arith.if( ra rb rt imm )
+{
+rt = ra / rb
+}
+
+# divu
+def divu:Arith.if( ra rb rt imm )
+{
+rt = ra / rb
+}
+
+# sll
+def sll:Arith.if( ra rb rt imm )
+{
+rt = ra << rb
+}
+
+# srl
+def srl:Arith.if( ra rb rt imm )
+{
+rt = ra >> rb
+}
+
+# sra
+def sra:Arith.if( ra rb rt imm )
+{
+rt = ra >> rb
+}
+
+# and
+def and:Arith.if( ra rb rt imm )
+{
+rt = ra & rb
+}
+
+# or
+def or:Arith.if( ra rb rt imm )
+{
+rt = ra | rb
+}
+
+# nand
+def nand:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra & rb)
+}
+
+# nor
+def nor:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra | rb)
+}
+
+# xor
+def xor:Arith.if( ra rb rt imm )
+{
+rt = ra ^ rb
+}
+
+# cmp.ne
+def cmp.ne:Arith.if( ra rb rt imm )
+{
+if( ra != rb ){ rt = 2 }else{ rt = 0 }
+}
+
+# cmp.eq
+def cmp.eq:Arith.if( ra rb rt imm )
+{
+if( ra == rb ){ rt = 3 }else{ rt = 0 }
+}
+
+# cmp.gt
+def cmp.gt:Arith.if( ra rb rt imm )
+{
+if( ra > rb ){ rt = 4 }else{ rt = 0 }
+}
+
+# cmp.lt
+def cmp.lt:Arith.if( ra rb rt imm )
+{
+if( ra < rb ){ rt = 5 }else{ rt = 0 }
+}
+
+# cmp.gte
+def cmp.gte:Arith.if( ra rb rt imm )
+{
+if( ra >= rb ){ rt = 6 }else{ rt = 0 }
+}
+
+# cmp.lte
+def cmp.lte:Arith.if( ra rb rt imm )
+{
+if( ra <= rb ){ rt = 7 }else{ rt = 0 }
+}
+
+# lb
+def lb:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,8),7)
+}
+
+# lh
+def lh:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,16),15)
+}
+
+# lw
+def lw:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,32),31)
+}
+
+# ld
+def ld:Arith.if( ra rb rt imm )
+{
+rt = LOADELEM(ra+imm,64)
+}
+
+# sb
+def sb:Arith.if( ra rb rt imm )
+{
+STOREELEM(ra,rt+imm,8)
+}
+
+# sh
+def sh:Arith.if( ra rb rt imm )
+{
+STOREELEM(SEXT(ra,15),rt+imm,16)
+}
+
+# sw
+def sw:Arith.if( ra rb rt imm )
+{
+STOREELEM(SEXT(ra,31),rt+imm,32)
+}
+
+# sd
+def sd:Arith.if( ra rb rt imm )
+{
+STOREELEM(ra,rt+imm,64)
+}
+
+# lbu
+def lbu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,8),7)
+}
+
+# lhu
+def lhu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,16),15)
+}
+
+# lwu
+def lwu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,32),31)
+}
+
+# sbu
+def sbu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,7),rt+imm,8)
+}
+
+# shu
+def shu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,15),rt+imm,16)
+}
+
+# swu
+def swu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,31),rt+imm,32)
+}
+
+# not
+def not:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra)
+}
+
+# bra
+def bra:Arith.if( ra rb rt imm )
+{
+pc = rt
+}
+
+# br
+def br:Arith.if( ra rb rt imm )
+{
+pc = pc + rt
+}
+
+# cadd
+def cadd:ReadCtrl.if( ra rb rt imm )
+{
+rt = ra + rb
+}
+
+# brac
+def brac:ReadCtrl.if( ra rb rt imm )
+{
+if( ra == rb ){ pc = rt }else{ pc = pc + 4 }
+}
+
+# brc
+def brc:ReadCtrl.if( ra rb rt imm )
+{
+if( ra == rb ){ pc = pc + rt }else{ pc = pc + 4 }
+}
+
+# ladd
+def ladd:WriteCtrl.if( ra rb rt imm )
+{
+rt = ra + rb
+}
+


### PR DESCRIPTION
This PR contains support in the SCSigMap pass for discovering and inserting pipeline metadata into the CoreGenSigMap object for each respective signal.  This includes support for adding the signals from each instruction in SCSigMap as well as reading/writing the CoreGenSigMap yaml.  The final commit contains tests for all of the above.  