### PR TITLE
adding syntax support for pipeline targets

### DIFF
--- a/include/CoreGen/CoreGenSigMap/CoreGenSigMap.h
+++ b/include/CoreGen/CoreGenSigMap/CoreGenSigMap.h
@@ -42,9 +42,11 @@ private:
 
   std::vector<SigType> TopSigs;   ///< CoreGenSigMap: top-level signals
 
-  unsigned TmpIdx;
+  unsigned TmpIdx;                ///< CoreGenSigMap: Temporary index
 
-  std::string Error;
+  std::string Error;              ///< CoreGenSigMap: Error string
+
+  std::string SigFile;            ///< CoreGenSigMap: Output file
 
   // private functions
   /// Writes the top-level signal map to the YAML file
@@ -108,6 +110,12 @@ public:
 
   /// Retrieves the number of signals in the signal map
   unsigned GetNumSignals() { return Signals.size(); }
+
+  /// Retrieves a vector of the pipeline stages found in the included signals
+  std::vector<std::string> GetPipeVect();
+
+  /// Write the signal map
+  bool WriteSigMap();
 
   /// Write the signal map to the target file
   bool WriteSigMap( std::string File );

--- a/include/CoreGen/StoneCutter/Passes/SCPipeBuilder.h
+++ b/include/CoreGen/StoneCutter/Passes/SCPipeBuilder.h
@@ -23,15 +23,35 @@
 #include <map>
 #include <vector>
 #include "CoreGen/StoneCutter/SCPass.h"
+#include "CoreGen/CoreGenSigMap/CoreGenSigMap.h"
 
 class SCPipeBuilder : public SCPass {
 private:
 
-  std::vector<unsigned> ArithOps;   ///< Pipline arithmetic operations
-  std::vector<unsigned> ShiftOps;   ///< Pipline shift operations
+  CoreGenSigMap *SigMap;              ///< SCPipeBuilder: Signal map object
 
-  /// Construct the arithmetic pipeline
-  bool BuildArithPipe();
+  std::vector<std::string> PipeVect;  ///< SCPipeBuilder: Pipe vector
+  std::vector<std::string> InstVect;  ///< SCPipeBuilder: Instruction vector
+
+  unsigned **AdjMat;                  ///< SCPipeBuilder: Adjacency Matrix
+
+  /// SCPipeBuilder: Build the matrix representation
+  bool BuildMat();
+
+  /// SCPipeBuilder: Writes the pipeline back to the signal map
+  bool WriteSigMap();
+
+  /// SCPipeBuilder: Allocates the adjacency matrix
+  bool AllocMat();
+
+  /// SCPipeBuilder: Frees the adjacency matrix
+  bool FreeMat();
+
+  /// SCPipeBuilder: Execute the various optimization phases
+  bool Optimize();
+
+  /// SCPipeBuilder: Retrives the x-axis idx from the pipe stage name
+  unsigned PipeToIdx(std::string P);
 
 public:
   /// Default cosntructor
@@ -39,6 +59,9 @@ public:
 
   /// Default destructor
   ~SCPipeBuilder();
+
+  /// Set the signal map object
+  bool SetSignalMap(CoreGenSigMap *CSM){ SigMap = CSM; return true; }
 
   /// Execute the codegen
   virtual bool Execute() override;

--- a/include/CoreGen/StoneCutter/SCChiselCodeGen.h
+++ b/include/CoreGen/StoneCutter/SCChiselCodeGen.h
@@ -94,6 +94,7 @@ private:
   void InitPasses();                          ///< Init the pass vector
   bool ExecutePasses();                       ///< Executes all the code generation passes
   bool ExecuteSignalMap();                    ///< Executes the signal map generator
+  bool ExecutePipelineOpt();                  ///< Executes the pipeline optimizer
   bool ExecuteUcodeCodegen();                 ///< Executes a microcode codegen using sigmaps
   bool ExecuteManualCodegen();                ///< Executes a manual codegen
 

--- a/include/CoreGen/StoneCutter/SCParser.h
+++ b/include/CoreGen/StoneCutter/SCParser.h
@@ -148,15 +148,18 @@ public:
   /// PipeExprAST - Expression class for pipe regions
   class PipeExprASTContainer : public ExprASTContainer {
     std::string PipeName;                                     ///< Name of the target pipe stage
+    std::string PipeLine;                                     ///< Pipeline designator
     unsigned Instance;                                        ///< Instance of the pipe stage
     std::vector<std::unique_ptr<ExprASTContainer>> BodyExpr;  ///< Vector of body expressions
 
   public:
     /// PipExprASTContainer default constructor
     PipeExprASTContainer(std::string PipeName,
+                         std::string PipeLine,
                          unsigned Instance,
                          std::vector<std::unique_ptr<ExprASTContainer>> BodyExpr)
-      : PipeName(PipeName), Instance(Instance), BodyExpr(std::move(BodyExpr)) {}
+      : PipeName(PipeName), PipeLine(PipeLine), Instance(Instance),
+        BodyExpr(std::move(BodyExpr)) {}
 
     /// PipeExprASTContainer code generation driver
     Value *codegen() override;
@@ -406,6 +409,7 @@ public:
   static SCMsg *GMsgs;                                                                  ///< Global message handler
   static MDNode *NameMDNode;                                                            ///< Pipe name metadata node
   static MDNode *InstanceMDNode;                                                        ///< Pipe instance metadata node
+  static MDNode *PipelineMDNode;                                                        ///< Pipeline name metadata node
 
 private:
 

--- a/src/CoreGenSigMap/CoreGenSigMap.cpp
+++ b/src/CoreGenSigMap/CoreGenSigMap.cpp
@@ -114,11 +114,20 @@ unsigned CoreGenSigMap::GetMinSignalWidth( unsigned Idx ){
   return Min;
 }
 
+bool CoreGenSigMap::WriteSigMap(){
+  if( SigFile.length() > 0 )
+    return WriteSigMap(SigFile);
+  return false;
+}
+
 bool CoreGenSigMap::WriteSigMap( std::string File ){
   if( File.length() == 0 )
     return false;
   if( Signals.size() == 0 )
     return false;
+
+  // set the file name
+  SigFile = File;
 
   // open the file
   std::ofstream OutYaml(File.c_str());
@@ -432,6 +441,8 @@ bool CoreGenSigMap::ReadSigMap( std::string File ){
   if( File.length() == 0 )
     return false;
 
+  SigFile = File;
+
   // load the file
   YAML::Node IR;
   try{
@@ -499,6 +510,20 @@ std::vector<SCSig *> CoreGenSigMap::GetSigVect(std::string Inst){
     }
   }
   return CSigs;
+}
+
+std::vector<std::string> CoreGenSigMap::GetPipeVect(){
+  std::vector<std::string> V;
+
+  for( unsigned i=0; i<Signals.size(); i++ ){
+    if( Signals[i]->IsPipeDefined() ){
+      V.push_back(Signals[i]->GetPipeName());
+    }
+  }
+
+  std::sort( V.begin(), V.end() );
+  V.erase( std::unique(V.begin(),V.end()), V.end() );
+  return V;
 }
 
 bool CoreGenSigMap::WriteInstSignals(YAML::Emitter *out){

--- a/src/StoneCutter/Passes/SCPipeBuilder.cpp
+++ b/src/StoneCutter/Passes/SCPipeBuilder.cpp
@@ -14,27 +14,87 @@ SCPipeBuilder::SCPipeBuilder(Module *TM,
                              SCOpts *O,
                              SCMsg *M)
   : SCPass("PipeBuilder","",TM,O,M) {
+  AdjMat = nullptr;
 }
 
 SCPipeBuilder::~SCPipeBuilder(){
 }
 
-bool SCPipeBuilder::BuildArithPipe(){
+unsigned SCPipeBuilder::PipeToIdx(std::string P){
+  for( unsigned i=0; i<PipeVect.size(); i++ ){
+    if( PipeVect[i] == P )
+      return i;
+  }
 
-  // walk all the functions
-  for(auto &Func : TheModule->getFunctionList() ){
-    // walk all the basic blocks
-    for(auto &BB : Func.getBasicBlockList() ){
-      // walk all the instructions
-      for(auto &Inst : BB.getInstList() ){
-        // evaluate each instruction
-        if( Inst.isBinaryOp() || Inst.isBitwiseLogicOp() ){
-          ArithOps.push_back(Inst.getOpcode());
-        }else if( Inst.isShift() ){
-          ShiftOps.push_back(Inst.getOpcode());
-        }
+  return PipeVect.size();
+}
+
+bool SCPipeBuilder::Optimize(){
+  return true;
+}
+
+bool SCPipeBuilder::BuildMat(){
+
+  SCSig *Sig = nullptr;
+  unsigned Idx = PipeVect.size();
+
+  for( unsigned i=0; i<SigMap->GetNumSignals(); i++ ){
+    Sig = SigMap->GetSignal(i);
+    if( Sig->IsPipeDefined() ){
+      Idx = PipeToIdx(Sig->GetPipeName());
+      if( Idx == PipeVect.size() ){
+        this->PrintMsg( L_ERROR, "Pipe stage unknown" );
+        return false;
+      }
+      AdjMat[Idx][i] = 1;
+    }
+  }
+
+  return true;
+}
+
+bool SCPipeBuilder::WriteSigMap(){
+  for( unsigned i=0; i<SigMap->GetNumSignals(); i++ ){
+    for( unsigned j=0; j<PipeVect.size(); j++ ){
+      if( AdjMat[j][i] == 1 ){
+        SigMap->GetSignal(i)->SetPipeName(PipeVect[j]);
       }
     }
+  }
+  return SigMap->WriteSigMap();
+}
+
+bool SCPipeBuilder::AllocMat(){
+  if( AdjMat != nullptr )
+    return false;
+
+  AdjMat = new unsigned*[PipeVect.size()];
+  if( AdjMat == nullptr )
+    return false;
+
+  for( unsigned i=0; i<PipeVect.size(); i++ ){
+    AdjMat[i] = new unsigned[SigMap->GetNumSignals()];
+    if( AdjMat[i] == nullptr )
+      return false;
+  }
+
+  for( unsigned i=0; i<PipeVect.size(); i++ ){
+    for( unsigned j=0; j<SigMap->GetNumSignals(); j++ ){
+      AdjMat[i][j] = 0;
+    }
+  }
+  return true;
+}
+
+bool SCPipeBuilder::FreeMat(){
+  if( AdjMat == nullptr )
+    return true;
+
+  if( AdjMat != nullptr ){
+    for( unsigned i=0; i<PipeVect.size(); i++ ){
+      delete [] AdjMat[i];
+    }
+    delete [] AdjMat;
   }
 
   return true;
@@ -46,7 +106,43 @@ bool SCPipeBuilder::Execute(){
     return false;
   }
 
-  if( !BuildArithPipe() ){
+  // retrieve the pipeline stage vector
+  PipeVect = SigMap->GetPipeVect();
+  InstVect = SigMap->GetInstVect();
+
+  // TODO: what if no pipeline stages are defined?
+  //       different optimization path?
+
+  // allocate the matrix
+  if( !AllocMat() ){
+    this->PrintMsg( L_ERROR, "Could not allocate matrix" );
+    return false;
+  }
+
+  // build the pipeline matrix
+  if( !BuildMat() ){
+    this->PrintMsg( L_ERROR, "Could not build matrix representation of pipeline" );
+    FreeMat();
+    return false;
+  }
+
+  // execute optimizations
+  if( !Optimize() ){
+    this->PrintMsg( L_ERROR, "Encountered errors executing the the optimization phases" );
+    FreeMat();
+    return false;
+  }
+
+  // write everything back to the sigmapA
+  if( !WriteSigMap() ){
+    this->PrintMsg( L_ERROR, "Could not write signal map for the prescribed pipeline" );
+    FreeMat();
+    return false;
+  }
+
+  // free the matrix
+  if( !FreeMat() ){
+    this->PrintMsg( L_ERROR, "Could not free adjacency matrix" );
     return false;
   }
 

--- a/src/StoneCutter/SCChiselCodeGen.cpp
+++ b/src/StoneCutter/SCChiselCodeGen.cpp
@@ -69,9 +69,6 @@ void SCChiselCodeGen::InitPasses(){
   Passes.push_back(static_cast<SCPass *>(new SCInstFormat(SCParser::TheModule.get(),
                                                        Opts,
                                                        Msgs)));
-  Passes.push_back(static_cast<SCPass *>(new SCPipeBuilder(SCParser::TheModule.get(),
-                                                       Opts,
-                                                       Msgs)));
   Passes.push_back(static_cast<SCPass *>(new SCIOWarn(SCParser::TheModule.get(),
                                                       Opts,
                                                       Msgs)));
@@ -1505,11 +1502,72 @@ bool SCChiselCodeGen::WriteUCodeCompiler(){
   return true;
 }
 
+bool SCChiselCodeGen::ExecutePipelineOpt(){
+  SCPipeBuilder *PB = new SCPipeBuilder(SCParser::TheModule.get(),
+                                        Opts,
+                                        Msgs);
+  if( !PB )
+    return false;
+
+  // set the options
+  std::map<std::string,std::string> PassOpts = Opts->GetSCPassOptions();
+  std::map<std::string,std::string>::iterator mit;
+  mit = PassOpts.find(PB->GetName());
+  if( mit != PassOpts.end() )
+    PB->SetExecOpts(mit->second);
+
+  // set the signal map
+  if( PB->SetSignalMap(CSM) ){
+    delete PB;
+    return false;
+  }
+
+  // execute the pass
+  bool rtn = true;
+  if( !Opts->IsDisableSCPass() && !Opts->IsEnableSCPass() ){
+    if( !PB->Execute() )
+      rtn = false;
+  }else if( Opts->IsEnableSCPass() ){
+    // manually enabled passes
+    std::vector<std::string> E = Opts->GetEnableSCPass();
+    std::vector<SCPass *>::iterator it;
+    std::vector<std::string>::iterator str;
+    str = std::find(E.begin(),E.end(),PB->GetName());
+    if( str != E.end() ){
+      if( !PB->Execute() )
+        rtn = false;
+    }
+
+  }else if( Opts->IsDisableSCPass() ){
+    // manually disabled passes
+    std::vector<std::string> D = Opts->GetDisabledSCPass();
+    std::vector<SCPass *>::iterator it;
+    std::vector<std::string>::iterator str;
+    str = std::find(D.begin(),D.end(),PB->GetName());
+    if( str == D.end() ){
+      if( !PB->Execute() )
+        rtn = false;
+    }
+  }
+
+  // delete the signal map object
+  delete PB;
+
+  return rtn;
+}
+
 bool SCChiselCodeGen::ExecuteCodegen(){
 
   // Execute all the necessary passes
   if( !Opts->IsPassRun() ){
     if( !ExecutePasses() ){
+      return false;
+    }
+  }
+
+  // attempt to perform pipeline optimization
+  if( CSM ){
+    if( !ExecutePipelineOpt() ){
       return false;
     }
   }

--- a/test/StoneCutter/OptParser/KnownPass/sc_optparser_test141.sc
+++ b/test/StoneCutter/OptParser/KnownPass/sc_optparser_test141.sc
@@ -1,0 +1,258 @@
+#-- StoneCutter source file for ISA=BasicRISC.ISA
+
+
+# Instruction Formats
+instformat Arith.if(reg[GPR] ra,reg[GPR] rb,reg[GPR] rt,enc opc,enc func,imm imm)
+instformat ReadCtrl.if(reg[GPR] ra,reg[CTRL] rb,reg[GPR] rt,enc opc,enc func,imm imm)
+instformat WriteCtrl.if(reg[GPR] ra,reg[GPR] rb,reg[CTRL] rt,enc opc,enc func,imm imm)
+
+# Register Class Definitions
+regclass GPR( u64 r0, u64 r1, u64 r2, u64 r3, u64 r4, u64 r5, u64 r6, u64 r7, u64 r8, u64 r9, u64 r10, u64 r11, u64 r12, u64 r13, u64 r14, u64 r15, u64 r16, u64 r17, u64 r18, u64 r19, u64 r20, u64 r21, u64 r22, u64 r23, u64 r24, u64 r25, u64 r26, u64 r27, u64 r28, u64 r29, u64 r30, u64 r31 )
+regclass CTRL( u64 pc[PC], u64 exc, u64 ne, u64 eq, u64 gt, u64 lt, u64 gte, u64 lte, u64 sp, u64 fp, u64 rp )
+
+
+# Instruction Definitions
+# add
+def add:Arith.if( ra rb rt imm )
+{
+  pipe p0:integer_pipeline{
+    rt = ra + rb
+  }
+}
+
+# sub
+def sub:Arith.if( ra rb rt imm )
+{
+  pipe p0:integer_pipeline{
+    rt = ra - rb
+  }
+}
+
+# mul
+def mul:Arith.if( ra rb rt imm )
+{
+rt = ra * rb
+}
+
+# div
+def div:Arith.if( ra rb rt imm )
+{
+rt = ra / rb
+}
+
+# divu
+def divu:Arith.if( ra rb rt imm )
+{
+rt = ra / rb
+}
+
+# sll
+def sll:Arith.if( ra rb rt imm )
+{
+rt = ra << rb
+}
+
+# srl
+def srl:Arith.if( ra rb rt imm )
+{
+rt = ra >> rb
+}
+
+# sra
+def sra:Arith.if( ra rb rt imm )
+{
+rt = ra >> rb
+}
+
+# and
+def and:Arith.if( ra rb rt imm )
+{
+rt = ra & rb
+}
+
+# or
+def or:Arith.if( ra rb rt imm )
+{
+rt = ra | rb
+}
+
+# nand
+def nand:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra & rb)
+}
+
+# nor
+def nor:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra | rb)
+}
+
+# xor
+def xor:Arith.if( ra rb rt imm )
+{
+rt = ra ^ rb
+}
+
+# cmp.ne
+def cmp.ne:Arith.if( ra rb rt imm )
+{
+if( ra != rb ){ rt = 2 }else{ rt = 0 }
+}
+
+# cmp.eq
+def cmp.eq:Arith.if( ra rb rt imm )
+{
+if( ra == rb ){ rt = 3 }else{ rt = 0 }
+}
+
+# cmp.gt
+def cmp.gt:Arith.if( ra rb rt imm )
+{
+if( ra > rb ){ rt = 4 }else{ rt = 0 }
+}
+
+# cmp.lt
+def cmp.lt:Arith.if( ra rb rt imm )
+{
+if( ra < rb ){ rt = 5 }else{ rt = 0 }
+}
+
+# cmp.gte
+def cmp.gte:Arith.if( ra rb rt imm )
+{
+if( ra >= rb ){ rt = 6 }else{ rt = 0 }
+}
+
+# cmp.lte
+def cmp.lte:Arith.if( ra rb rt imm )
+{
+if( ra <= rb ){ rt = 7 }else{ rt = 0 }
+}
+
+# lb
+def lb:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,8),7)
+}
+
+# lh
+def lh:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,16),15)
+}
+
+# lw
+def lw:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,32),31)
+}
+
+# ld
+def ld:Arith.if( ra rb rt imm )
+{
+rt = LOADELEM(ra+imm,64)
+}
+
+# sb
+def sb:Arith.if( ra rb rt imm )
+{
+STOREELEM(ra,rt+imm,8)
+}
+
+# sh
+def sh:Arith.if( ra rb rt imm )
+{
+STOREELEM(SEXT(ra,15),rt+imm,16)
+}
+
+# sw
+def sw:Arith.if( ra rb rt imm )
+{
+STOREELEM(SEXT(ra,31),rt+imm,32)
+}
+
+# sd
+def sd:Arith.if( ra rb rt imm )
+{
+STOREELEM(ra,rt+imm,64)
+}
+
+# lbu
+def lbu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,8),7)
+}
+
+# lhu
+def lhu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,16),15)
+}
+
+# lwu
+def lwu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,32),31)
+}
+
+# sbu
+def sbu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,7),rt+imm,8)
+}
+
+# shu
+def shu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,15),rt+imm,16)
+}
+
+# swu
+def swu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,31),rt+imm,32)
+}
+
+# not
+def not:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra)
+}
+
+# bra
+def bra:Arith.if( ra rb rt imm )
+{
+pc = rt
+}
+
+# br
+def br:Arith.if( ra rb rt imm )
+{
+pc = pc + rt
+}
+
+# cadd
+def cadd:ReadCtrl.if( ra rb rt imm )
+{
+rt = ra + rb
+}
+
+# brac
+def brac:ReadCtrl.if( ra rb rt imm )
+{
+if( ra == rb ){ pc = rt }else{ pc = pc + 4 }
+}
+
+# brc
+def brc:ReadCtrl.if( ra rb rt imm )
+{
+if( ra == rb ){ pc = pc + rt }else{ pc = pc + 4 }
+}
+
+# ladd
+def ladd:WriteCtrl.if( ra rb rt imm )
+{
+rt = ra + rb
+}
+

--- a/test/StoneCutter/OptParser/KnownPass/sc_optparser_test142.sc
+++ b/test/StoneCutter/OptParser/KnownPass/sc_optparser_test142.sc
@@ -1,0 +1,258 @@
+#-- StoneCutter source file for ISA=BasicRISC.ISA
+
+
+# Instruction Formats
+instformat Arith.if(reg[GPR] ra,reg[GPR] rb,reg[GPR] rt,enc opc,enc func,imm imm)
+instformat ReadCtrl.if(reg[GPR] ra,reg[CTRL] rb,reg[GPR] rt,enc opc,enc func,imm imm)
+instformat WriteCtrl.if(reg[GPR] ra,reg[GPR] rb,reg[CTRL] rt,enc opc,enc func,imm imm)
+
+# Register Class Definitions
+regclass GPR( u64 r0, u64 r1, u64 r2, u64 r3, u64 r4, u64 r5, u64 r6, u64 r7, u64 r8, u64 r9, u64 r10, u64 r11, u64 r12, u64 r13, u64 r14, u64 r15, u64 r16, u64 r17, u64 r18, u64 r19, u64 r20, u64 r21, u64 r22, u64 r23, u64 r24, u64 r25, u64 r26, u64 r27, u64 r28, u64 r29, u64 r30, u64 r31 )
+regclass CTRL( u64 pc[PC], u64 exc, u64 ne, u64 eq, u64 gt, u64 lt, u64 gte, u64 lte, u64 sp, u64 fp, u64 rp )
+
+
+# Instruction Definitions
+# add
+def add:Arith.if( ra rb rt imm )
+{
+  pipe p0:integer_pipeline{
+    rt = ra + rb
+  }
+}
+
+# sub
+def sub:Arith.if( ra rb rt imm )
+{
+  pipe p1:integer_pipeline{
+    rt = ra - rb
+  }
+}
+
+# mul
+def mul:Arith.if( ra rb rt imm )
+{
+rt = ra * rb
+}
+
+# div
+def div:Arith.if( ra rb rt imm )
+{
+rt = ra / rb
+}
+
+# divu
+def divu:Arith.if( ra rb rt imm )
+{
+rt = ra / rb
+}
+
+# sll
+def sll:Arith.if( ra rb rt imm )
+{
+rt = ra << rb
+}
+
+# srl
+def srl:Arith.if( ra rb rt imm )
+{
+rt = ra >> rb
+}
+
+# sra
+def sra:Arith.if( ra rb rt imm )
+{
+rt = ra >> rb
+}
+
+# and
+def and:Arith.if( ra rb rt imm )
+{
+rt = ra & rb
+}
+
+# or
+def or:Arith.if( ra rb rt imm )
+{
+rt = ra | rb
+}
+
+# nand
+def nand:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra & rb)
+}
+
+# nor
+def nor:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra | rb)
+}
+
+# xor
+def xor:Arith.if( ra rb rt imm )
+{
+rt = ra ^ rb
+}
+
+# cmp.ne
+def cmp.ne:Arith.if( ra rb rt imm )
+{
+if( ra != rb ){ rt = 2 }else{ rt = 0 }
+}
+
+# cmp.eq
+def cmp.eq:Arith.if( ra rb rt imm )
+{
+if( ra == rb ){ rt = 3 }else{ rt = 0 }
+}
+
+# cmp.gt
+def cmp.gt:Arith.if( ra rb rt imm )
+{
+if( ra > rb ){ rt = 4 }else{ rt = 0 }
+}
+
+# cmp.lt
+def cmp.lt:Arith.if( ra rb rt imm )
+{
+if( ra < rb ){ rt = 5 }else{ rt = 0 }
+}
+
+# cmp.gte
+def cmp.gte:Arith.if( ra rb rt imm )
+{
+if( ra >= rb ){ rt = 6 }else{ rt = 0 }
+}
+
+# cmp.lte
+def cmp.lte:Arith.if( ra rb rt imm )
+{
+if( ra <= rb ){ rt = 7 }else{ rt = 0 }
+}
+
+# lb
+def lb:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,8),7)
+}
+
+# lh
+def lh:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,16),15)
+}
+
+# lw
+def lw:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,32),31)
+}
+
+# ld
+def ld:Arith.if( ra rb rt imm )
+{
+rt = LOADELEM(ra+imm,64)
+}
+
+# sb
+def sb:Arith.if( ra rb rt imm )
+{
+STOREELEM(ra,rt+imm,8)
+}
+
+# sh
+def sh:Arith.if( ra rb rt imm )
+{
+STOREELEM(SEXT(ra,15),rt+imm,16)
+}
+
+# sw
+def sw:Arith.if( ra rb rt imm )
+{
+STOREELEM(SEXT(ra,31),rt+imm,32)
+}
+
+# sd
+def sd:Arith.if( ra rb rt imm )
+{
+STOREELEM(ra,rt+imm,64)
+}
+
+# lbu
+def lbu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,8),7)
+}
+
+# lhu
+def lhu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,16),15)
+}
+
+# lwu
+def lwu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,32),31)
+}
+
+# sbu
+def sbu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,7),rt+imm,8)
+}
+
+# shu
+def shu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,15),rt+imm,16)
+}
+
+# swu
+def swu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,31),rt+imm,32)
+}
+
+# not
+def not:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra)
+}
+
+# bra
+def bra:Arith.if( ra rb rt imm )
+{
+pc = rt
+}
+
+# br
+def br:Arith.if( ra rb rt imm )
+{
+pc = pc + rt
+}
+
+# cadd
+def cadd:ReadCtrl.if( ra rb rt imm )
+{
+rt = ra + rb
+}
+
+# brac
+def brac:ReadCtrl.if( ra rb rt imm )
+{
+if( ra == rb ){ pc = rt }else{ pc = pc + 4 }
+}
+
+# brc
+def brc:ReadCtrl.if( ra rb rt imm )
+{
+if( ra == rb ){ pc = pc + rt }else{ pc = pc + 4 }
+}
+
+# ladd
+def ladd:WriteCtrl.if( ra rb rt imm )
+{
+rt = ra + rb
+}
+

--- a/test/StoneCutter/OptParser/KnownPass/sc_optparser_test143.sc
+++ b/test/StoneCutter/OptParser/KnownPass/sc_optparser_test143.sc
@@ -1,0 +1,269 @@
+#-- StoneCutter source file for ISA=BasicRISC.ISA
+
+
+# Instruction Formats
+instformat Arith.if(reg[GPR] ra,reg[GPR] rb,reg[GPR] rt,enc opc,enc func,imm imm)
+instformat ReadCtrl.if(reg[GPR] ra,reg[CTRL] rb,reg[GPR] rt,enc opc,enc func,imm imm)
+instformat WriteCtrl.if(reg[GPR] ra,reg[GPR] rb,reg[CTRL] rt,enc opc,enc func,imm imm)
+
+# Register Class Definitions
+regclass GPR( u64 r0, u64 r1, u64 r2, u64 r3, u64 r4, u64 r5, u64 r6, u64 r7, u64 r8, u64 r9, u64 r10, u64 r11, u64 r12, u64 r13, u64 r14, u64 r15, u64 r16, u64 r17, u64 r18, u64 r19, u64 r20, u64 r21, u64 r22, u64 r23, u64 r24, u64 r25, u64 r26, u64 r27, u64 r28, u64 r29, u64 r30, u64 r31 )
+regclass CTRL( u64 pc[PC], u64 exc, u64 ne, u64 eq, u64 gt, u64 lt, u64 gte, u64 lte, u64 sp, u64 fp, u64 rp )
+
+
+# Instruction Definitions
+# FMA
+def fma:Arith.if( ra rb rt imm )
+{
+  pipe p0:integer_pipeline{
+    rt = ra + rb
+  }
+  pipe p1:integer_pipeline{
+    rt = rt * imm
+  }
+}
+
+# add
+def add:Arith.if( ra rb rt imm )
+{
+  pipe p0:integer_pipeline{
+    rt = ra + rb
+  }
+}
+
+# sub
+def sub:Arith.if( ra rb rt imm )
+{
+  pipe p1:integer_pipeline{
+    rt = ra - rb
+  }
+}
+
+# mul
+def mul:Arith.if( ra rb rt imm )
+{
+rt = ra * rb
+}
+
+# div
+def div:Arith.if( ra rb rt imm )
+{
+rt = ra / rb
+}
+
+# divu
+def divu:Arith.if( ra rb rt imm )
+{
+rt = ra / rb
+}
+
+# sll
+def sll:Arith.if( ra rb rt imm )
+{
+rt = ra << rb
+}
+
+# srl
+def srl:Arith.if( ra rb rt imm )
+{
+rt = ra >> rb
+}
+
+# sra
+def sra:Arith.if( ra rb rt imm )
+{
+rt = ra >> rb
+}
+
+# and
+def and:Arith.if( ra rb rt imm )
+{
+rt = ra & rb
+}
+
+# or
+def or:Arith.if( ra rb rt imm )
+{
+rt = ra | rb
+}
+
+# nand
+def nand:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra & rb)
+}
+
+# nor
+def nor:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra | rb)
+}
+
+# xor
+def xor:Arith.if( ra rb rt imm )
+{
+rt = ra ^ rb
+}
+
+# cmp.ne
+def cmp.ne:Arith.if( ra rb rt imm )
+{
+if( ra != rb ){ rt = 2 }else{ rt = 0 }
+}
+
+# cmp.eq
+def cmp.eq:Arith.if( ra rb rt imm )
+{
+if( ra == rb ){ rt = 3 }else{ rt = 0 }
+}
+
+# cmp.gt
+def cmp.gt:Arith.if( ra rb rt imm )
+{
+if( ra > rb ){ rt = 4 }else{ rt = 0 }
+}
+
+# cmp.lt
+def cmp.lt:Arith.if( ra rb rt imm )
+{
+if( ra < rb ){ rt = 5 }else{ rt = 0 }
+}
+
+# cmp.gte
+def cmp.gte:Arith.if( ra rb rt imm )
+{
+if( ra >= rb ){ rt = 6 }else{ rt = 0 }
+}
+
+# cmp.lte
+def cmp.lte:Arith.if( ra rb rt imm )
+{
+if( ra <= rb ){ rt = 7 }else{ rt = 0 }
+}
+
+# lb
+def lb:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,8),7)
+}
+
+# lh
+def lh:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,16),15)
+}
+
+# lw
+def lw:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,32),31)
+}
+
+# ld
+def ld:Arith.if( ra rb rt imm )
+{
+rt = LOADELEM(ra+imm,64)
+}
+
+# sb
+def sb:Arith.if( ra rb rt imm )
+{
+STOREELEM(ra,rt+imm,8)
+}
+
+# sh
+def sh:Arith.if( ra rb rt imm )
+{
+STOREELEM(SEXT(ra,15),rt+imm,16)
+}
+
+# sw
+def sw:Arith.if( ra rb rt imm )
+{
+STOREELEM(SEXT(ra,31),rt+imm,32)
+}
+
+# sd
+def sd:Arith.if( ra rb rt imm )
+{
+STOREELEM(ra,rt+imm,64)
+}
+
+# lbu
+def lbu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,8),7)
+}
+
+# lhu
+def lhu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,16),15)
+}
+
+# lwu
+def lwu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,32),31)
+}
+
+# sbu
+def sbu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,7),rt+imm,8)
+}
+
+# shu
+def shu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,15),rt+imm,16)
+}
+
+# swu
+def swu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,31),rt+imm,32)
+}
+
+# not
+def not:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra)
+}
+
+# bra
+def bra:Arith.if( ra rb rt imm )
+{
+pc = rt
+}
+
+# br
+def br:Arith.if( ra rb rt imm )
+{
+pc = pc + rt
+}
+
+# cadd
+def cadd:ReadCtrl.if( ra rb rt imm )
+{
+rt = ra + rb
+}
+
+# brac
+def brac:ReadCtrl.if( ra rb rt imm )
+{
+if( ra == rb ){ pc = rt }else{ pc = pc + 4 }
+}
+
+# brc
+def brc:ReadCtrl.if( ra rb rt imm )
+{
+if( ra == rb ){ pc = pc + rt }else{ pc = pc + 4 }
+}
+
+# ladd
+def ladd:WriteCtrl.if( ra rb rt imm )
+{
+rt = ra + rb
+}
+

--- a/test/StoneCutter/OptParser/KnownPass/sc_optparser_test144.sc
+++ b/test/StoneCutter/OptParser/KnownPass/sc_optparser_test144.sc
@@ -1,0 +1,269 @@
+#-- StoneCutter source file for ISA=BasicRISC.ISA
+
+
+# Instruction Formats
+instformat Arith.if(reg[GPR] ra,reg[GPR] rb,reg[GPR] rt,enc opc,enc func,imm imm)
+instformat ReadCtrl.if(reg[GPR] ra,reg[CTRL] rb,reg[GPR] rt,enc opc,enc func,imm imm)
+instformat WriteCtrl.if(reg[GPR] ra,reg[GPR] rb,reg[CTRL] rt,enc opc,enc func,imm imm)
+
+# Register Class Definitions
+regclass GPR( u64 r0, u64 r1, u64 r2, u64 r3, u64 r4, u64 r5, u64 r6, u64 r7, u64 r8, u64 r9, u64 r10, u64 r11, u64 r12, u64 r13, u64 r14, u64 r15, u64 r16, u64 r17, u64 r18, u64 r19, u64 r20, u64 r21, u64 r22, u64 r23, u64 r24, u64 r25, u64 r26, u64 r27, u64 r28, u64 r29, u64 r30, u64 r31 )
+regclass CTRL( u64 pc[PC], u64 exc, u64 ne, u64 eq, u64 gt, u64 lt, u64 gte, u64 lte, u64 sp, u64 fp, u64 rp )
+
+
+# Instruction Definitions
+# FMA
+def fma:Arith.if( ra rb rt imm )
+{
+  pipe p0:pipeline1{
+    rt = ra + rb
+  }
+  pipe p1:pipeline2{
+    rt = rt * imm
+  }
+}
+
+# add
+def add:Arith.if( ra rb rt imm )
+{
+  pipe p0:integer_pipeline{
+    rt = ra + rb
+  }
+}
+
+# sub
+def sub:Arith.if( ra rb rt imm )
+{
+  pipe p1:integer_pipeline{
+    rt = ra - rb
+  }
+}
+
+# mul
+def mul:Arith.if( ra rb rt imm )
+{
+rt = ra * rb
+}
+
+# div
+def div:Arith.if( ra rb rt imm )
+{
+rt = ra / rb
+}
+
+# divu
+def divu:Arith.if( ra rb rt imm )
+{
+rt = ra / rb
+}
+
+# sll
+def sll:Arith.if( ra rb rt imm )
+{
+rt = ra << rb
+}
+
+# srl
+def srl:Arith.if( ra rb rt imm )
+{
+rt = ra >> rb
+}
+
+# sra
+def sra:Arith.if( ra rb rt imm )
+{
+rt = ra >> rb
+}
+
+# and
+def and:Arith.if( ra rb rt imm )
+{
+rt = ra & rb
+}
+
+# or
+def or:Arith.if( ra rb rt imm )
+{
+rt = ra | rb
+}
+
+# nand
+def nand:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra & rb)
+}
+
+# nor
+def nor:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra | rb)
+}
+
+# xor
+def xor:Arith.if( ra rb rt imm )
+{
+rt = ra ^ rb
+}
+
+# cmp.ne
+def cmp.ne:Arith.if( ra rb rt imm )
+{
+if( ra != rb ){ rt = 2 }else{ rt = 0 }
+}
+
+# cmp.eq
+def cmp.eq:Arith.if( ra rb rt imm )
+{
+if( ra == rb ){ rt = 3 }else{ rt = 0 }
+}
+
+# cmp.gt
+def cmp.gt:Arith.if( ra rb rt imm )
+{
+if( ra > rb ){ rt = 4 }else{ rt = 0 }
+}
+
+# cmp.lt
+def cmp.lt:Arith.if( ra rb rt imm )
+{
+if( ra < rb ){ rt = 5 }else{ rt = 0 }
+}
+
+# cmp.gte
+def cmp.gte:Arith.if( ra rb rt imm )
+{
+if( ra >= rb ){ rt = 6 }else{ rt = 0 }
+}
+
+# cmp.lte
+def cmp.lte:Arith.if( ra rb rt imm )
+{
+if( ra <= rb ){ rt = 7 }else{ rt = 0 }
+}
+
+# lb
+def lb:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,8),7)
+}
+
+# lh
+def lh:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,16),15)
+}
+
+# lw
+def lw:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,32),31)
+}
+
+# ld
+def ld:Arith.if( ra rb rt imm )
+{
+rt = LOADELEM(ra+imm,64)
+}
+
+# sb
+def sb:Arith.if( ra rb rt imm )
+{
+STOREELEM(ra,rt+imm,8)
+}
+
+# sh
+def sh:Arith.if( ra rb rt imm )
+{
+STOREELEM(SEXT(ra,15),rt+imm,16)
+}
+
+# sw
+def sw:Arith.if( ra rb rt imm )
+{
+STOREELEM(SEXT(ra,31),rt+imm,32)
+}
+
+# sd
+def sd:Arith.if( ra rb rt imm )
+{
+STOREELEM(ra,rt+imm,64)
+}
+
+# lbu
+def lbu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,8),7)
+}
+
+# lhu
+def lhu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,16),15)
+}
+
+# lwu
+def lwu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,32),31)
+}
+
+# sbu
+def sbu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,7),rt+imm,8)
+}
+
+# shu
+def shu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,15),rt+imm,16)
+}
+
+# swu
+def swu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,31),rt+imm,32)
+}
+
+# not
+def not:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra)
+}
+
+# bra
+def bra:Arith.if( ra rb rt imm )
+{
+pc = rt
+}
+
+# br
+def br:Arith.if( ra rb rt imm )
+{
+pc = pc + rt
+}
+
+# cadd
+def cadd:ReadCtrl.if( ra rb rt imm )
+{
+rt = ra + rb
+}
+
+# brac
+def brac:ReadCtrl.if( ra rb rt imm )
+{
+if( ra == rb ){ pc = rt }else{ pc = pc + 4 }
+}
+
+# brc
+def brc:ReadCtrl.if( ra rb rt imm )
+{
+if( ra == rb ){ pc = pc + rt }else{ pc = pc + 4 }
+}
+
+# ladd
+def ladd:WriteCtrl.if( ra rb rt imm )
+{
+rt = ra + rb
+}
+

--- a/test/StoneCutter/Parser/KnownFail/sc_parser_test114_KF.sc
+++ b/test/StoneCutter/Parser/KnownFail/sc_parser_test114_KF.sc
@@ -1,0 +1,258 @@
+#-- StoneCutter source file for ISA=BasicRISC.ISA
+
+
+# Instruction Formats
+instformat Arith.if(reg[GPR] ra,reg[GPR] rb,reg[GPR] rt,enc opc,enc func,imm imm)
+instformat ReadCtrl.if(reg[GPR] ra,reg[CTRL] rb,reg[GPR] rt,enc opc,enc func,imm imm)
+instformat WriteCtrl.if(reg[GPR] ra,reg[GPR] rb,reg[CTRL] rt,enc opc,enc func,imm imm)
+
+# Register Class Definitions
+regclass GPR( u64 r0, u64 r1, u64 r2, u64 r3, u64 r4, u64 r5, u64 r6, u64 r7, u64 r8, u64 r9, u64 r10, u64 r11, u64 r12, u64 r13, u64 r14, u64 r15, u64 r16, u64 r17, u64 r18, u64 r19, u64 r20, u64 r21, u64 r22, u64 r23, u64 r24, u64 r25, u64 r26, u64 r27, u64 r28, u64 r29, u64 r30, u64 r31 )
+regclass CTRL( u64 pc[PC], u64 exc, u64 ne, u64 eq, u64 gt, u64 lt, u64 gte, u64 lte, u64 sp, u64 fp, u64 rp )
+
+
+# Instruction Definitions
+# add
+def add:Arith.if( ra rb rt imm )
+{
+  pipe p0:{
+    rt = ra + rb
+  }
+}
+
+# sub
+def sub:Arith.if( ra rb rt imm )
+{
+  pipe p0:integer_pipeline{
+    rt = ra - rb
+  }
+}
+
+# mul
+def mul:Arith.if( ra rb rt imm )
+{
+rt = ra * rb
+}
+
+# div
+def div:Arith.if( ra rb rt imm )
+{
+rt = ra / rb
+}
+
+# divu
+def divu:Arith.if( ra rb rt imm )
+{
+rt = ra / rb
+}
+
+# sll
+def sll:Arith.if( ra rb rt imm )
+{
+rt = ra << rb
+}
+
+# srl
+def srl:Arith.if( ra rb rt imm )
+{
+rt = ra >> rb
+}
+
+# sra
+def sra:Arith.if( ra rb rt imm )
+{
+rt = ra >> rb
+}
+
+# and
+def and:Arith.if( ra rb rt imm )
+{
+rt = ra & rb
+}
+
+# or
+def or:Arith.if( ra rb rt imm )
+{
+rt = ra | rb
+}
+
+# nand
+def nand:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra & rb)
+}
+
+# nor
+def nor:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra | rb)
+}
+
+# xor
+def xor:Arith.if( ra rb rt imm )
+{
+rt = ra ^ rb
+}
+
+# cmp.ne
+def cmp.ne:Arith.if( ra rb rt imm )
+{
+if( ra != rb ){ rt = 2 }else{ rt = 0 }
+}
+
+# cmp.eq
+def cmp.eq:Arith.if( ra rb rt imm )
+{
+if( ra == rb ){ rt = 3 }else{ rt = 0 }
+}
+
+# cmp.gt
+def cmp.gt:Arith.if( ra rb rt imm )
+{
+if( ra > rb ){ rt = 4 }else{ rt = 0 }
+}
+
+# cmp.lt
+def cmp.lt:Arith.if( ra rb rt imm )
+{
+if( ra < rb ){ rt = 5 }else{ rt = 0 }
+}
+
+# cmp.gte
+def cmp.gte:Arith.if( ra rb rt imm )
+{
+if( ra >= rb ){ rt = 6 }else{ rt = 0 }
+}
+
+# cmp.lte
+def cmp.lte:Arith.if( ra rb rt imm )
+{
+if( ra <= rb ){ rt = 7 }else{ rt = 0 }
+}
+
+# lb
+def lb:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,8),7)
+}
+
+# lh
+def lh:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,16),15)
+}
+
+# lw
+def lw:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,32),31)
+}
+
+# ld
+def ld:Arith.if( ra rb rt imm )
+{
+rt = LOADELEM(ra+imm,64)
+}
+
+# sb
+def sb:Arith.if( ra rb rt imm )
+{
+STOREELEM(ra,rt+imm,8)
+}
+
+# sh
+def sh:Arith.if( ra rb rt imm )
+{
+STOREELEM(SEXT(ra,15),rt+imm,16)
+}
+
+# sw
+def sw:Arith.if( ra rb rt imm )
+{
+STOREELEM(SEXT(ra,31),rt+imm,32)
+}
+
+# sd
+def sd:Arith.if( ra rb rt imm )
+{
+STOREELEM(ra,rt+imm,64)
+}
+
+# lbu
+def lbu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,8),7)
+}
+
+# lhu
+def lhu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,16),15)
+}
+
+# lwu
+def lwu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,32),31)
+}
+
+# sbu
+def sbu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,7),rt+imm,8)
+}
+
+# shu
+def shu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,15),rt+imm,16)
+}
+
+# swu
+def swu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,31),rt+imm,32)
+}
+
+# not
+def not:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra)
+}
+
+# bra
+def bra:Arith.if( ra rb rt imm )
+{
+pc = rt
+}
+
+# br
+def br:Arith.if( ra rb rt imm )
+{
+pc = pc + rt
+}
+
+# cadd
+def cadd:ReadCtrl.if( ra rb rt imm )
+{
+rt = ra + rb
+}
+
+# brac
+def brac:ReadCtrl.if( ra rb rt imm )
+{
+if( ra == rb ){ pc = rt }else{ pc = pc + 4 }
+}
+
+# brc
+def brc:ReadCtrl.if( ra rb rt imm )
+{
+if( ra == rb ){ pc = pc + rt }else{ pc = pc + 4 }
+}
+
+# ladd
+def ladd:WriteCtrl.if( ra rb rt imm )
+{
+rt = ra + rb
+}
+

--- a/test/StoneCutter/Parser/KnownFail/sc_parser_test115_KF.sc
+++ b/test/StoneCutter/Parser/KnownFail/sc_parser_test115_KF.sc
@@ -1,0 +1,258 @@
+#-- StoneCutter source file for ISA=BasicRISC.ISA
+
+
+# Instruction Formats
+instformat Arith.if(reg[GPR] ra,reg[GPR] rb,reg[GPR] rt,enc opc,enc func,imm imm)
+instformat ReadCtrl.if(reg[GPR] ra,reg[CTRL] rb,reg[GPR] rt,enc opc,enc func,imm imm)
+instformat WriteCtrl.if(reg[GPR] ra,reg[GPR] rb,reg[CTRL] rt,enc opc,enc func,imm imm)
+
+# Register Class Definitions
+regclass GPR( u64 r0, u64 r1, u64 r2, u64 r3, u64 r4, u64 r5, u64 r6, u64 r7, u64 r8, u64 r9, u64 r10, u64 r11, u64 r12, u64 r13, u64 r14, u64 r15, u64 r16, u64 r17, u64 r18, u64 r19, u64 r20, u64 r21, u64 r22, u64 r23, u64 r24, u64 r25, u64 r26, u64 r27, u64 r28, u64 r29, u64 r30, u64 r31 )
+regclass CTRL( u64 pc[PC], u64 exc, u64 ne, u64 eq, u64 gt, u64 lt, u64 gte, u64 lte, u64 sp, u64 fp, u64 rp )
+
+
+# Instruction Definitions
+# add
+def add:Arith.if( ra rb rt imm )
+{
+  pipe :pipeline1{
+    rt = ra + rb
+  }
+}
+
+# sub
+def sub:Arith.if( ra rb rt imm )
+{
+  pipe p0:integer_pipeline{
+    rt = ra - rb
+  }
+}
+
+# mul
+def mul:Arith.if( ra rb rt imm )
+{
+rt = ra * rb
+}
+
+# div
+def div:Arith.if( ra rb rt imm )
+{
+rt = ra / rb
+}
+
+# divu
+def divu:Arith.if( ra rb rt imm )
+{
+rt = ra / rb
+}
+
+# sll
+def sll:Arith.if( ra rb rt imm )
+{
+rt = ra << rb
+}
+
+# srl
+def srl:Arith.if( ra rb rt imm )
+{
+rt = ra >> rb
+}
+
+# sra
+def sra:Arith.if( ra rb rt imm )
+{
+rt = ra >> rb
+}
+
+# and
+def and:Arith.if( ra rb rt imm )
+{
+rt = ra & rb
+}
+
+# or
+def or:Arith.if( ra rb rt imm )
+{
+rt = ra | rb
+}
+
+# nand
+def nand:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra & rb)
+}
+
+# nor
+def nor:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra | rb)
+}
+
+# xor
+def xor:Arith.if( ra rb rt imm )
+{
+rt = ra ^ rb
+}
+
+# cmp.ne
+def cmp.ne:Arith.if( ra rb rt imm )
+{
+if( ra != rb ){ rt = 2 }else{ rt = 0 }
+}
+
+# cmp.eq
+def cmp.eq:Arith.if( ra rb rt imm )
+{
+if( ra == rb ){ rt = 3 }else{ rt = 0 }
+}
+
+# cmp.gt
+def cmp.gt:Arith.if( ra rb rt imm )
+{
+if( ra > rb ){ rt = 4 }else{ rt = 0 }
+}
+
+# cmp.lt
+def cmp.lt:Arith.if( ra rb rt imm )
+{
+if( ra < rb ){ rt = 5 }else{ rt = 0 }
+}
+
+# cmp.gte
+def cmp.gte:Arith.if( ra rb rt imm )
+{
+if( ra >= rb ){ rt = 6 }else{ rt = 0 }
+}
+
+# cmp.lte
+def cmp.lte:Arith.if( ra rb rt imm )
+{
+if( ra <= rb ){ rt = 7 }else{ rt = 0 }
+}
+
+# lb
+def lb:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,8),7)
+}
+
+# lh
+def lh:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,16),15)
+}
+
+# lw
+def lw:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,32),31)
+}
+
+# ld
+def ld:Arith.if( ra rb rt imm )
+{
+rt = LOADELEM(ra+imm,64)
+}
+
+# sb
+def sb:Arith.if( ra rb rt imm )
+{
+STOREELEM(ra,rt+imm,8)
+}
+
+# sh
+def sh:Arith.if( ra rb rt imm )
+{
+STOREELEM(SEXT(ra,15),rt+imm,16)
+}
+
+# sw
+def sw:Arith.if( ra rb rt imm )
+{
+STOREELEM(SEXT(ra,31),rt+imm,32)
+}
+
+# sd
+def sd:Arith.if( ra rb rt imm )
+{
+STOREELEM(ra,rt+imm,64)
+}
+
+# lbu
+def lbu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,8),7)
+}
+
+# lhu
+def lhu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,16),15)
+}
+
+# lwu
+def lwu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,32),31)
+}
+
+# sbu
+def sbu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,7),rt+imm,8)
+}
+
+# shu
+def shu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,15),rt+imm,16)
+}
+
+# swu
+def swu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,31),rt+imm,32)
+}
+
+# not
+def not:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra)
+}
+
+# bra
+def bra:Arith.if( ra rb rt imm )
+{
+pc = rt
+}
+
+# br
+def br:Arith.if( ra rb rt imm )
+{
+pc = pc + rt
+}
+
+# cadd
+def cadd:ReadCtrl.if( ra rb rt imm )
+{
+rt = ra + rb
+}
+
+# brac
+def brac:ReadCtrl.if( ra rb rt imm )
+{
+if( ra == rb ){ pc = rt }else{ pc = pc + 4 }
+}
+
+# brc
+def brc:ReadCtrl.if( ra rb rt imm )
+{
+if( ra == rb ){ pc = pc + rt }else{ pc = pc + 4 }
+}
+
+# ladd
+def ladd:WriteCtrl.if( ra rb rt imm )
+{
+rt = ra + rb
+}
+

--- a/test/StoneCutter/Parser/KnownPass/sc_parser_test139.sc
+++ b/test/StoneCutter/Parser/KnownPass/sc_parser_test139.sc
@@ -1,0 +1,258 @@
+#-- StoneCutter source file for ISA=BasicRISC.ISA
+
+
+# Instruction Formats
+instformat Arith.if(reg[GPR] ra,reg[GPR] rb,reg[GPR] rt,enc opc,enc func,imm imm)
+instformat ReadCtrl.if(reg[GPR] ra,reg[CTRL] rb,reg[GPR] rt,enc opc,enc func,imm imm)
+instformat WriteCtrl.if(reg[GPR] ra,reg[GPR] rb,reg[CTRL] rt,enc opc,enc func,imm imm)
+
+# Register Class Definitions
+regclass GPR( u64 r0, u64 r1, u64 r2, u64 r3, u64 r4, u64 r5, u64 r6, u64 r7, u64 r8, u64 r9, u64 r10, u64 r11, u64 r12, u64 r13, u64 r14, u64 r15, u64 r16, u64 r17, u64 r18, u64 r19, u64 r20, u64 r21, u64 r22, u64 r23, u64 r24, u64 r25, u64 r26, u64 r27, u64 r28, u64 r29, u64 r30, u64 r31 )
+regclass CTRL( u64 pc[PC], u64 exc, u64 ne, u64 eq, u64 gt, u64 lt, u64 gte, u64 lte, u64 sp, u64 fp, u64 rp )
+
+
+# Instruction Definitions
+# add
+def add:Arith.if( ra rb rt imm )
+{
+  pipe p0:integer_pipeline{
+    rt = ra + rb
+  }
+}
+
+# sub
+def sub:Arith.if( ra rb rt imm )
+{
+  pipe p0:integer_pipeline{
+    rt = ra - rb
+  }
+}
+
+# mul
+def mul:Arith.if( ra rb rt imm )
+{
+rt = ra * rb
+}
+
+# div
+def div:Arith.if( ra rb rt imm )
+{
+rt = ra / rb
+}
+
+# divu
+def divu:Arith.if( ra rb rt imm )
+{
+rt = ra / rb
+}
+
+# sll
+def sll:Arith.if( ra rb rt imm )
+{
+rt = ra << rb
+}
+
+# srl
+def srl:Arith.if( ra rb rt imm )
+{
+rt = ra >> rb
+}
+
+# sra
+def sra:Arith.if( ra rb rt imm )
+{
+rt = ra >> rb
+}
+
+# and
+def and:Arith.if( ra rb rt imm )
+{
+rt = ra & rb
+}
+
+# or
+def or:Arith.if( ra rb rt imm )
+{
+rt = ra | rb
+}
+
+# nand
+def nand:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra & rb)
+}
+
+# nor
+def nor:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra | rb)
+}
+
+# xor
+def xor:Arith.if( ra rb rt imm )
+{
+rt = ra ^ rb
+}
+
+# cmp.ne
+def cmp.ne:Arith.if( ra rb rt imm )
+{
+if( ra != rb ){ rt = 2 }else{ rt = 0 }
+}
+
+# cmp.eq
+def cmp.eq:Arith.if( ra rb rt imm )
+{
+if( ra == rb ){ rt = 3 }else{ rt = 0 }
+}
+
+# cmp.gt
+def cmp.gt:Arith.if( ra rb rt imm )
+{
+if( ra > rb ){ rt = 4 }else{ rt = 0 }
+}
+
+# cmp.lt
+def cmp.lt:Arith.if( ra rb rt imm )
+{
+if( ra < rb ){ rt = 5 }else{ rt = 0 }
+}
+
+# cmp.gte
+def cmp.gte:Arith.if( ra rb rt imm )
+{
+if( ra >= rb ){ rt = 6 }else{ rt = 0 }
+}
+
+# cmp.lte
+def cmp.lte:Arith.if( ra rb rt imm )
+{
+if( ra <= rb ){ rt = 7 }else{ rt = 0 }
+}
+
+# lb
+def lb:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,8),7)
+}
+
+# lh
+def lh:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,16),15)
+}
+
+# lw
+def lw:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,32),31)
+}
+
+# ld
+def ld:Arith.if( ra rb rt imm )
+{
+rt = LOADELEM(ra+imm,64)
+}
+
+# sb
+def sb:Arith.if( ra rb rt imm )
+{
+STOREELEM(ra,rt+imm,8)
+}
+
+# sh
+def sh:Arith.if( ra rb rt imm )
+{
+STOREELEM(SEXT(ra,15),rt+imm,16)
+}
+
+# sw
+def sw:Arith.if( ra rb rt imm )
+{
+STOREELEM(SEXT(ra,31),rt+imm,32)
+}
+
+# sd
+def sd:Arith.if( ra rb rt imm )
+{
+STOREELEM(ra,rt+imm,64)
+}
+
+# lbu
+def lbu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,8),7)
+}
+
+# lhu
+def lhu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,16),15)
+}
+
+# lwu
+def lwu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,32),31)
+}
+
+# sbu
+def sbu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,7),rt+imm,8)
+}
+
+# shu
+def shu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,15),rt+imm,16)
+}
+
+# swu
+def swu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,31),rt+imm,32)
+}
+
+# not
+def not:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra)
+}
+
+# bra
+def bra:Arith.if( ra rb rt imm )
+{
+pc = rt
+}
+
+# br
+def br:Arith.if( ra rb rt imm )
+{
+pc = pc + rt
+}
+
+# cadd
+def cadd:ReadCtrl.if( ra rb rt imm )
+{
+rt = ra + rb
+}
+
+# brac
+def brac:ReadCtrl.if( ra rb rt imm )
+{
+if( ra == rb ){ pc = rt }else{ pc = pc + 4 }
+}
+
+# brc
+def brc:ReadCtrl.if( ra rb rt imm )
+{
+if( ra == rb ){ pc = pc + rt }else{ pc = pc + 4 }
+}
+
+# ladd
+def ladd:WriteCtrl.if( ra rb rt imm )
+{
+rt = ra + rb
+}
+

--- a/test/StoneCutter/Parser/KnownPass/sc_parser_test140.sc
+++ b/test/StoneCutter/Parser/KnownPass/sc_parser_test140.sc
@@ -1,0 +1,258 @@
+#-- StoneCutter source file for ISA=BasicRISC.ISA
+
+
+# Instruction Formats
+instformat Arith.if(reg[GPR] ra,reg[GPR] rb,reg[GPR] rt,enc opc,enc func,imm imm)
+instformat ReadCtrl.if(reg[GPR] ra,reg[CTRL] rb,reg[GPR] rt,enc opc,enc func,imm imm)
+instformat WriteCtrl.if(reg[GPR] ra,reg[GPR] rb,reg[CTRL] rt,enc opc,enc func,imm imm)
+
+# Register Class Definitions
+regclass GPR( u64 r0, u64 r1, u64 r2, u64 r3, u64 r4, u64 r5, u64 r6, u64 r7, u64 r8, u64 r9, u64 r10, u64 r11, u64 r12, u64 r13, u64 r14, u64 r15, u64 r16, u64 r17, u64 r18, u64 r19, u64 r20, u64 r21, u64 r22, u64 r23, u64 r24, u64 r25, u64 r26, u64 r27, u64 r28, u64 r29, u64 r30, u64 r31 )
+regclass CTRL( u64 pc[PC], u64 exc, u64 ne, u64 eq, u64 gt, u64 lt, u64 gte, u64 lte, u64 sp, u64 fp, u64 rp )
+
+
+# Instruction Definitions
+# add
+def add:Arith.if( ra rb rt imm )
+{
+  pipe p0:integer_pipeline{
+    rt = ra + rb
+  }
+}
+
+# sub
+def sub:Arith.if( ra rb rt imm )
+{
+  pipe p1:integer_pipeline{
+    rt = ra - rb
+  }
+}
+
+# mul
+def mul:Arith.if( ra rb rt imm )
+{
+rt = ra * rb
+}
+
+# div
+def div:Arith.if( ra rb rt imm )
+{
+rt = ra / rb
+}
+
+# divu
+def divu:Arith.if( ra rb rt imm )
+{
+rt = ra / rb
+}
+
+# sll
+def sll:Arith.if( ra rb rt imm )
+{
+rt = ra << rb
+}
+
+# srl
+def srl:Arith.if( ra rb rt imm )
+{
+rt = ra >> rb
+}
+
+# sra
+def sra:Arith.if( ra rb rt imm )
+{
+rt = ra >> rb
+}
+
+# and
+def and:Arith.if( ra rb rt imm )
+{
+rt = ra & rb
+}
+
+# or
+def or:Arith.if( ra rb rt imm )
+{
+rt = ra | rb
+}
+
+# nand
+def nand:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra & rb)
+}
+
+# nor
+def nor:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra | rb)
+}
+
+# xor
+def xor:Arith.if( ra rb rt imm )
+{
+rt = ra ^ rb
+}
+
+# cmp.ne
+def cmp.ne:Arith.if( ra rb rt imm )
+{
+if( ra != rb ){ rt = 2 }else{ rt = 0 }
+}
+
+# cmp.eq
+def cmp.eq:Arith.if( ra rb rt imm )
+{
+if( ra == rb ){ rt = 3 }else{ rt = 0 }
+}
+
+# cmp.gt
+def cmp.gt:Arith.if( ra rb rt imm )
+{
+if( ra > rb ){ rt = 4 }else{ rt = 0 }
+}
+
+# cmp.lt
+def cmp.lt:Arith.if( ra rb rt imm )
+{
+if( ra < rb ){ rt = 5 }else{ rt = 0 }
+}
+
+# cmp.gte
+def cmp.gte:Arith.if( ra rb rt imm )
+{
+if( ra >= rb ){ rt = 6 }else{ rt = 0 }
+}
+
+# cmp.lte
+def cmp.lte:Arith.if( ra rb rt imm )
+{
+if( ra <= rb ){ rt = 7 }else{ rt = 0 }
+}
+
+# lb
+def lb:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,8),7)
+}
+
+# lh
+def lh:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,16),15)
+}
+
+# lw
+def lw:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,32),31)
+}
+
+# ld
+def ld:Arith.if( ra rb rt imm )
+{
+rt = LOADELEM(ra+imm,64)
+}
+
+# sb
+def sb:Arith.if( ra rb rt imm )
+{
+STOREELEM(ra,rt+imm,8)
+}
+
+# sh
+def sh:Arith.if( ra rb rt imm )
+{
+STOREELEM(SEXT(ra,15),rt+imm,16)
+}
+
+# sw
+def sw:Arith.if( ra rb rt imm )
+{
+STOREELEM(SEXT(ra,31),rt+imm,32)
+}
+
+# sd
+def sd:Arith.if( ra rb rt imm )
+{
+STOREELEM(ra,rt+imm,64)
+}
+
+# lbu
+def lbu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,8),7)
+}
+
+# lhu
+def lhu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,16),15)
+}
+
+# lwu
+def lwu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,32),31)
+}
+
+# sbu
+def sbu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,7),rt+imm,8)
+}
+
+# shu
+def shu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,15),rt+imm,16)
+}
+
+# swu
+def swu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,31),rt+imm,32)
+}
+
+# not
+def not:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra)
+}
+
+# bra
+def bra:Arith.if( ra rb rt imm )
+{
+pc = rt
+}
+
+# br
+def br:Arith.if( ra rb rt imm )
+{
+pc = pc + rt
+}
+
+# cadd
+def cadd:ReadCtrl.if( ra rb rt imm )
+{
+rt = ra + rb
+}
+
+# brac
+def brac:ReadCtrl.if( ra rb rt imm )
+{
+if( ra == rb ){ pc = rt }else{ pc = pc + 4 }
+}
+
+# brc
+def brc:ReadCtrl.if( ra rb rt imm )
+{
+if( ra == rb ){ pc = pc + rt }else{ pc = pc + 4 }
+}
+
+# ladd
+def ladd:WriteCtrl.if( ra rb rt imm )
+{
+rt = ra + rb
+}
+

--- a/test/StoneCutter/Parser/KnownPass/sc_parser_test141.sc
+++ b/test/StoneCutter/Parser/KnownPass/sc_parser_test141.sc
@@ -1,0 +1,269 @@
+#-- StoneCutter source file for ISA=BasicRISC.ISA
+
+
+# Instruction Formats
+instformat Arith.if(reg[GPR] ra,reg[GPR] rb,reg[GPR] rt,enc opc,enc func,imm imm)
+instformat ReadCtrl.if(reg[GPR] ra,reg[CTRL] rb,reg[GPR] rt,enc opc,enc func,imm imm)
+instformat WriteCtrl.if(reg[GPR] ra,reg[GPR] rb,reg[CTRL] rt,enc opc,enc func,imm imm)
+
+# Register Class Definitions
+regclass GPR( u64 r0, u64 r1, u64 r2, u64 r3, u64 r4, u64 r5, u64 r6, u64 r7, u64 r8, u64 r9, u64 r10, u64 r11, u64 r12, u64 r13, u64 r14, u64 r15, u64 r16, u64 r17, u64 r18, u64 r19, u64 r20, u64 r21, u64 r22, u64 r23, u64 r24, u64 r25, u64 r26, u64 r27, u64 r28, u64 r29, u64 r30, u64 r31 )
+regclass CTRL( u64 pc[PC], u64 exc, u64 ne, u64 eq, u64 gt, u64 lt, u64 gte, u64 lte, u64 sp, u64 fp, u64 rp )
+
+
+# Instruction Definitions
+# FMA
+def fma:Arith.if( ra rb rt imm )
+{
+  pipe p0:integer_pipeline{
+    rt = ra + rb
+  }
+  pipe p1:integer_pipeline{
+    rt = rt * imm
+  }
+}
+
+# add
+def add:Arith.if( ra rb rt imm )
+{
+  pipe p0:integer_pipeline{
+    rt = ra + rb
+  }
+}
+
+# sub
+def sub:Arith.if( ra rb rt imm )
+{
+  pipe p1:integer_pipeline{
+    rt = ra - rb
+  }
+}
+
+# mul
+def mul:Arith.if( ra rb rt imm )
+{
+rt = ra * rb
+}
+
+# div
+def div:Arith.if( ra rb rt imm )
+{
+rt = ra / rb
+}
+
+# divu
+def divu:Arith.if( ra rb rt imm )
+{
+rt = ra / rb
+}
+
+# sll
+def sll:Arith.if( ra rb rt imm )
+{
+rt = ra << rb
+}
+
+# srl
+def srl:Arith.if( ra rb rt imm )
+{
+rt = ra >> rb
+}
+
+# sra
+def sra:Arith.if( ra rb rt imm )
+{
+rt = ra >> rb
+}
+
+# and
+def and:Arith.if( ra rb rt imm )
+{
+rt = ra & rb
+}
+
+# or
+def or:Arith.if( ra rb rt imm )
+{
+rt = ra | rb
+}
+
+# nand
+def nand:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra & rb)
+}
+
+# nor
+def nor:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra | rb)
+}
+
+# xor
+def xor:Arith.if( ra rb rt imm )
+{
+rt = ra ^ rb
+}
+
+# cmp.ne
+def cmp.ne:Arith.if( ra rb rt imm )
+{
+if( ra != rb ){ rt = 2 }else{ rt = 0 }
+}
+
+# cmp.eq
+def cmp.eq:Arith.if( ra rb rt imm )
+{
+if( ra == rb ){ rt = 3 }else{ rt = 0 }
+}
+
+# cmp.gt
+def cmp.gt:Arith.if( ra rb rt imm )
+{
+if( ra > rb ){ rt = 4 }else{ rt = 0 }
+}
+
+# cmp.lt
+def cmp.lt:Arith.if( ra rb rt imm )
+{
+if( ra < rb ){ rt = 5 }else{ rt = 0 }
+}
+
+# cmp.gte
+def cmp.gte:Arith.if( ra rb rt imm )
+{
+if( ra >= rb ){ rt = 6 }else{ rt = 0 }
+}
+
+# cmp.lte
+def cmp.lte:Arith.if( ra rb rt imm )
+{
+if( ra <= rb ){ rt = 7 }else{ rt = 0 }
+}
+
+# lb
+def lb:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,8),7)
+}
+
+# lh
+def lh:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,16),15)
+}
+
+# lw
+def lw:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,32),31)
+}
+
+# ld
+def ld:Arith.if( ra rb rt imm )
+{
+rt = LOADELEM(ra+imm,64)
+}
+
+# sb
+def sb:Arith.if( ra rb rt imm )
+{
+STOREELEM(ra,rt+imm,8)
+}
+
+# sh
+def sh:Arith.if( ra rb rt imm )
+{
+STOREELEM(SEXT(ra,15),rt+imm,16)
+}
+
+# sw
+def sw:Arith.if( ra rb rt imm )
+{
+STOREELEM(SEXT(ra,31),rt+imm,32)
+}
+
+# sd
+def sd:Arith.if( ra rb rt imm )
+{
+STOREELEM(ra,rt+imm,64)
+}
+
+# lbu
+def lbu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,8),7)
+}
+
+# lhu
+def lhu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,16),15)
+}
+
+# lwu
+def lwu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,32),31)
+}
+
+# sbu
+def sbu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,7),rt+imm,8)
+}
+
+# shu
+def shu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,15),rt+imm,16)
+}
+
+# swu
+def swu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,31),rt+imm,32)
+}
+
+# not
+def not:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra)
+}
+
+# bra
+def bra:Arith.if( ra rb rt imm )
+{
+pc = rt
+}
+
+# br
+def br:Arith.if( ra rb rt imm )
+{
+pc = pc + rt
+}
+
+# cadd
+def cadd:ReadCtrl.if( ra rb rt imm )
+{
+rt = ra + rb
+}
+
+# brac
+def brac:ReadCtrl.if( ra rb rt imm )
+{
+if( ra == rb ){ pc = rt }else{ pc = pc + 4 }
+}
+
+# brc
+def brc:ReadCtrl.if( ra rb rt imm )
+{
+if( ra == rb ){ pc = pc + rt }else{ pc = pc + 4 }
+}
+
+# ladd
+def ladd:WriteCtrl.if( ra rb rt imm )
+{
+rt = ra + rb
+}
+

--- a/test/StoneCutter/Parser/KnownPass/sc_parser_test142.sc
+++ b/test/StoneCutter/Parser/KnownPass/sc_parser_test142.sc
@@ -1,0 +1,269 @@
+#-- StoneCutter source file for ISA=BasicRISC.ISA
+
+
+# Instruction Formats
+instformat Arith.if(reg[GPR] ra,reg[GPR] rb,reg[GPR] rt,enc opc,enc func,imm imm)
+instformat ReadCtrl.if(reg[GPR] ra,reg[CTRL] rb,reg[GPR] rt,enc opc,enc func,imm imm)
+instformat WriteCtrl.if(reg[GPR] ra,reg[GPR] rb,reg[CTRL] rt,enc opc,enc func,imm imm)
+
+# Register Class Definitions
+regclass GPR( u64 r0, u64 r1, u64 r2, u64 r3, u64 r4, u64 r5, u64 r6, u64 r7, u64 r8, u64 r9, u64 r10, u64 r11, u64 r12, u64 r13, u64 r14, u64 r15, u64 r16, u64 r17, u64 r18, u64 r19, u64 r20, u64 r21, u64 r22, u64 r23, u64 r24, u64 r25, u64 r26, u64 r27, u64 r28, u64 r29, u64 r30, u64 r31 )
+regclass CTRL( u64 pc[PC], u64 exc, u64 ne, u64 eq, u64 gt, u64 lt, u64 gte, u64 lte, u64 sp, u64 fp, u64 rp )
+
+
+# Instruction Definitions
+# FMA
+def fma:Arith.if( ra rb rt imm )
+{
+  pipe p0:pipeline1{
+    rt = ra + rb
+  }
+  pipe p1:pipeline2{
+    rt = rt * imm
+  }
+}
+
+# add
+def add:Arith.if( ra rb rt imm )
+{
+  pipe p0:integer_pipeline{
+    rt = ra + rb
+  }
+}
+
+# sub
+def sub:Arith.if( ra rb rt imm )
+{
+  pipe p1:integer_pipeline{
+    rt = ra - rb
+  }
+}
+
+# mul
+def mul:Arith.if( ra rb rt imm )
+{
+rt = ra * rb
+}
+
+# div
+def div:Arith.if( ra rb rt imm )
+{
+rt = ra / rb
+}
+
+# divu
+def divu:Arith.if( ra rb rt imm )
+{
+rt = ra / rb
+}
+
+# sll
+def sll:Arith.if( ra rb rt imm )
+{
+rt = ra << rb
+}
+
+# srl
+def srl:Arith.if( ra rb rt imm )
+{
+rt = ra >> rb
+}
+
+# sra
+def sra:Arith.if( ra rb rt imm )
+{
+rt = ra >> rb
+}
+
+# and
+def and:Arith.if( ra rb rt imm )
+{
+rt = ra & rb
+}
+
+# or
+def or:Arith.if( ra rb rt imm )
+{
+rt = ra | rb
+}
+
+# nand
+def nand:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra & rb)
+}
+
+# nor
+def nor:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra | rb)
+}
+
+# xor
+def xor:Arith.if( ra rb rt imm )
+{
+rt = ra ^ rb
+}
+
+# cmp.ne
+def cmp.ne:Arith.if( ra rb rt imm )
+{
+if( ra != rb ){ rt = 2 }else{ rt = 0 }
+}
+
+# cmp.eq
+def cmp.eq:Arith.if( ra rb rt imm )
+{
+if( ra == rb ){ rt = 3 }else{ rt = 0 }
+}
+
+# cmp.gt
+def cmp.gt:Arith.if( ra rb rt imm )
+{
+if( ra > rb ){ rt = 4 }else{ rt = 0 }
+}
+
+# cmp.lt
+def cmp.lt:Arith.if( ra rb rt imm )
+{
+if( ra < rb ){ rt = 5 }else{ rt = 0 }
+}
+
+# cmp.gte
+def cmp.gte:Arith.if( ra rb rt imm )
+{
+if( ra >= rb ){ rt = 6 }else{ rt = 0 }
+}
+
+# cmp.lte
+def cmp.lte:Arith.if( ra rb rt imm )
+{
+if( ra <= rb ){ rt = 7 }else{ rt = 0 }
+}
+
+# lb
+def lb:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,8),7)
+}
+
+# lh
+def lh:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,16),15)
+}
+
+# lw
+def lw:Arith.if( ra rb rt imm )
+{
+rt = SEXT(LOADELEM(ra+imm,32),31)
+}
+
+# ld
+def ld:Arith.if( ra rb rt imm )
+{
+rt = LOADELEM(ra+imm,64)
+}
+
+# sb
+def sb:Arith.if( ra rb rt imm )
+{
+STOREELEM(ra,rt+imm,8)
+}
+
+# sh
+def sh:Arith.if( ra rb rt imm )
+{
+STOREELEM(SEXT(ra,15),rt+imm,16)
+}
+
+# sw
+def sw:Arith.if( ra rb rt imm )
+{
+STOREELEM(SEXT(ra,31),rt+imm,32)
+}
+
+# sd
+def sd:Arith.if( ra rb rt imm )
+{
+STOREELEM(ra,rt+imm,64)
+}
+
+# lbu
+def lbu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,8),7)
+}
+
+# lhu
+def lhu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,16),15)
+}
+
+# lwu
+def lwu:Arith.if( ra rb rt imm )
+{
+rt = ZEXT(LOADELEM(ra+imm,32),31)
+}
+
+# sbu
+def sbu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,7),rt+imm,8)
+}
+
+# shu
+def shu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,15),rt+imm,16)
+}
+
+# swu
+def swu:Arith.if( ra rb rt imm )
+{
+STOREELEM(ZEXT(ra,31),rt+imm,32)
+}
+
+# not
+def not:Arith.if( ra rb rt imm )
+{
+rt = NOT(ra)
+}
+
+# bra
+def bra:Arith.if( ra rb rt imm )
+{
+pc = rt
+}
+
+# br
+def br:Arith.if( ra rb rt imm )
+{
+pc = pc + rt
+}
+
+# cadd
+def cadd:ReadCtrl.if( ra rb rt imm )
+{
+rt = ra + rb
+}
+
+# brac
+def brac:ReadCtrl.if( ra rb rt imm )
+{
+if( ra == rb ){ pc = rt }else{ pc = pc + 4 }
+}
+
+# brc
+def brc:ReadCtrl.if( ra rb rt imm )
+{
+if( ra == rb ){ pc = pc + rt }else{ pc = pc + 4 }
+}
+
+# ladd
+def ladd:WriteCtrl.if( ra rb rt imm )
+{
+rt = ra + rb
+}
+


### PR DESCRIPTION
Adding syntax support in StoneCutter for individual pipeline targets.  This PR doesn't yet support defining the pipelines with the associated attributes.  However, this PR does include the initial code refactoring for the SCPipeBuilder pass.  