### PR TITLE
Adding SMT parameter support to CoreGenCore node

### DIFF
--- a/include/CoreGen/CoreGenBackend/CoreGenCore.h
+++ b/include/CoreGen/CoreGenBackend/CoreGenCore.h
@@ -30,11 +30,19 @@
 #include "CoreGen/CoreGenBackend/CoreGenRegClass.h"
 #include "CoreGen/CoreGenBackend/CoreGenCache.h"
 
+typedef enum{
+  SMTUnk      = 0,			///< CGSched: Unknown SMT Scheduling
+  SMTPCycle   = 1,                      ///< CGSched: SMT P-Cycle Scheduling
+  SMTPressure = 2,                      ///< CGSched: SMT Pressure-Based Scheduling
+  SMTProg     = 3                       ///< CGSched: SMT Programmatic Scheduling
+}CGSched;                             	///< CoreGenCore: SMT Scheduling Types
+
 class CoreGenCore : public CoreGenNode{
 private:
   CoreGenCache *Cache;                  ///< CoreGenCore: First connected cache hierarchy
   CoreGenISA *ISA;                      ///< CoreGenCore: ISA Implementation
   unsigned ThreadUnits;                 ///< CoreGenCore: SMT Thread Units
+  CGSched Sched;			///< CoreGenCore: SMT Scheduler
 
   std::vector<CoreGenRegClass *> Regs;  ///< CoreGenCore: Supported registers
   std::vector<CoreGenNode *> Exts;      ///< CoreGenCore: Supported extensions
@@ -48,6 +56,9 @@ public:
 
   /// Set the instruction set
   bool SetISA( CoreGenISA *ISA );
+
+  /// Set the scheduler type
+  bool SetSched( CGSched Sched );
 
   /// Add a cache hierarchy
   bool InsertCache( CoreGenCache *Cache );
@@ -76,6 +87,9 @@ public:
   /// Retrieve the number of thread units
   unsigned GetNumThreadUnits() { return ThreadUnits; }
 
+  /// Retrieve the scheduler type
+  CGSched GetSched() { return Sched; }
+
   /// Retrieve the target register class
   CoreGenRegClass *GetRegClass( unsigned C );
 
@@ -93,6 +107,12 @@ public:
 
   /// Sets the ISA to null
   bool SetNullISA() { ISA = nullptr; return true; }
+
+  /// Converts scheduler type to string
+  std::string CGSchedToStr( CGSched S );
+
+  /// Converts a string to scheduler type
+  CGSched StrToCGSched( std::string Str );
 };
 
 #endif

--- a/include/CoreGen/CoreGenBackend/Passes/Analysis/CoreSafetyPass.h
+++ b/include/CoreGen/CoreGenBackend/Passes/Analysis/CoreSafetyPass.h
@@ -35,6 +35,9 @@ private:
   /// Searches for unconnected Cores
   bool FindDanglingCores(CoreGenDAG *D, CoreGenCore *Core, unsigned Idx);
 
+  /// Ensures the SMT configuration is correct
+  bool SMTConfig(CoreGenCore *Core);
+
 public:
   /// Default constructor
   CoreSafetyPass(std::ostream *O, CoreGenDAG *D, CoreGenErrno *E);

--- a/src/CoreGenBackend/CoreGenCore.cpp
+++ b/src/CoreGenBackend/CoreGenCore.cpp
@@ -11,12 +11,18 @@
 #include "CoreGen/CoreGenBackend/CoreGenCore.h"
 
 CoreGenCore::CoreGenCore( std::string N, CoreGenISA *I, CoreGenErrno *E)
-  : CoreGenNode(CGCore,N,E), Cache(NULL), ISA(I), ThreadUnits(1){
+  : CoreGenNode(CGCore,N,E), Cache(NULL), ISA(I), ThreadUnits(1),
+    Sched(SMTUnk){
   if( ISA )
     InsertChild(static_cast<CoreGenNode *>(ISA));
 }
 
 CoreGenCore::~CoreGenCore(){
+}
+
+bool CoreGenCore::SetSched( CGSched S ){
+  Sched = S;
+  return true;
 }
 
 bool CoreGenCore::SetISA( CoreGenISA *I ){
@@ -112,6 +118,42 @@ bool CoreGenCore::SetNumThreadUnits( unsigned TU ){
   }
   ThreadUnits = TU;
   return true;
+}
+
+std::string CoreGenCore::CGSchedToStr( CGSched S ){
+  switch( S ){
+  case SMTUnk:
+    return "Unknown";
+    break;
+  case SMTPCycle:
+    return "PCycle";
+    break;
+  case SMTPressure:
+    return "Pressure";
+    break;
+  case SMTProg:
+    return "Programmatic";
+    break;
+  default:
+    return "";
+    break;
+  }
+  return "";
+}
+
+CGSched CoreGenCore::StrToCGSched( std::string Str ){
+  if( Str == "Unknown" ){
+    return SMTUnk;
+  }else if( Str == "PCycle" ){
+    return SMTPCycle;
+  }else if( Str == "Pressure" ){
+    return SMTPressure;
+  }else if( Str == "Programmatic" ){
+    return SMTProg;
+  }else{
+    return SMTUnk;
+  }
+  return SMTUnk;
 }
 
 // EOF

--- a/test/DAG/IndividualPasses/KnownPass/CoreSafetyPass/CoreSafetyPass_TEST85.yaml
+++ b/test/DAG/IndividualPasses/KnownPass/CoreSafetyPass/CoreSafetyPass_TEST85.yaml
@@ -3165,8 +3165,8 @@ Extensions:
           - TEST74.ext0.reg
     ISAs:
       - ISAName: TEST74.ext0.isa
-    RTLFile: TEST74.ext0.v
-    RTLType: Verilog
+    RTLFile: TEST74.ext0.chisel
+    RTLType: Chisel
   - Extension: TEST74.ext1
     Type: unknown
     Registers:
@@ -3262,7 +3262,8 @@ Cores:
     Extensions:
       - Extension: TEST74.ext2
   - Core: TEST74.core3
-    ThreadUnits: 4
+    ThreadUnits: 1
+    Scheduler: Programmatic
     Cache: TEST74.core3.L1.cache
     ISA: TEST74.isa
     RegisterClasses:

--- a/test/Yaml/Reader/MissingData/TEST47.yaml
+++ b/test/Yaml/Reader/MissingData/TEST47.yaml
@@ -1,0 +1,167 @@
+Registers:
+  - RegName: TEST102.0.reg
+    Width: 64
+    Index: 0
+    PseudoName: pseudoreg.0
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.1.reg
+    Width: 64
+    Index: 1
+    PseudoName: pseudoreg.1
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.2.reg
+    Width: 64
+    Index: 2
+    PseudoName: pseudoreg.2
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.3.reg
+    Width: 64
+    Index: 3
+    PseudoName: pseudoreg.3
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.4.reg
+    Width: 64
+    Index: 4
+    PseudoName: pseudoreg.4
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.5.reg
+    Width: 64
+    Index: 5
+    PseudoName: pseudoreg.5
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.6.reg
+    Width: 64
+    Index: 6
+    PseudoName: pseudoreg.6
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.7.reg
+    Width: 64
+    Index: 7
+    PseudoName: pseudoreg.7
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.8.reg
+    Width: 64
+    Index: 8
+    PseudoName: pseudoreg.8
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+RegClasses:
+  - RegisterClassName: TEST102.regclass
+    NumRegisters: 16
+    Registers:
+      - TEST102.0.reg
+      - TEST102.1.reg
+      - TEST102.2.reg
+      - TEST102.3.reg
+      - TEST102.4.reg
+      - TEST102.5.reg
+      - TEST102.6.reg
+      - TEST102.7.reg
+      - TEST102.8.reg
+ISAs:
+  - ISAName: TEST102.isa
+InstFormats:
+  - InstFormatName: TEST102.if
+    ISA: TEST102.isa
+    FormatWidth: 8
+    Fields:
+      - FieldName: opcode
+        FieldType: CGInstCode
+        FieldWidth: 4
+        StartBit: 0
+        EndBit: 3
+        MandatoryField: true
+      - FieldName: ra
+        FieldType: CGInstReg
+        FieldWidth: 2
+        StartBit: 4 
+        EndBit: 5
+        MandatoryField: false
+        RegClass: TEST102.regclass
+        RegIsDestination: false
+      - FieldName: rb
+        FieldType: CGInstReg
+        FieldWidth: 2
+        StartBit: 6
+        EndBit: 7
+        MandatoryField: false
+        RegClass: TEST102.regclass
+        RegIsDestination: true 
+  - InstFormatName: TEST102a.if
+    ISA: TEST102.isa
+    FormatWidth: 8
+    Fields:
+      - FieldName: op
+        FieldType: CGInstCode
+        FieldWidth: 4
+        StartBit: 0
+        EndBit: 3
+        MandatoryField: true
+      - FieldName: rsrc
+        FieldType: CGInstReg
+        FieldWidth: 2
+        StartBit: 4 
+        EndBit: 5
+        MandatoryField: false
+        RegClass: TEST102.regclass
+      - FieldName: rdest
+        FieldType: CGInstReg
+        FieldWidth: 2
+        StartBit: 6
+        EndBit: 7
+        MandatoryField: false
+        RegClass: TEST102.regclass
+Cores:
+  - Core: TEST102.core
+    ISA: TEST102.isa
+    RegisterClasses:
+      - RegClass: TEST102.regclass
+    Scheduler:
+Socs:
+  - Soc: TEST102.soc
+    Cores:
+      - Core: TEST102.core

--- a/test/Yaml/Reader/MissingData/yaml_reader_missingdata_47.cpp
+++ b/test/Yaml/Reader/MissingData/yaml_reader_missingdata_47.cpp
@@ -1,0 +1,37 @@
+//
+// _YAML_READER_TEST47_CPP_
+//
+// Copyright (C) 2017-2018 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+// 
+//
+
+#include <iostream>
+#include "CoreGen/CoreGenBackend/CoreGenBackend.h"
+
+std::string PROJNAME = "TEST47";
+std::string PROJROOT = "./";
+std::string ARCHROOT = "./";
+std::string PROJYAML = "../TEST47.yaml";
+
+int main( int argc, char **argv ){
+  CoreGenBackend *CG = new CoreGenBackend(PROJNAME,
+                                          PROJROOT,
+                                          ARCHROOT);
+  if( !CG ){
+    std::cout << "ERROR : FAILED TO CREATE COREGEN OBJECT" << std::endl;
+    return -1;
+  }
+
+  if( !CG->ReadIR( PROJYAML ) ){
+    std::cout << "ERROR : FAILED TO READ YAML IR:" << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  delete CG;
+  return 0;
+}

--- a/test/Yaml/Reader/TEST103.yaml
+++ b/test/Yaml/Reader/TEST103.yaml
@@ -1,0 +1,167 @@
+Registers:
+  - RegName: TEST102.0.reg
+    Width: 64
+    Index: 0
+    PseudoName: pseudoreg.0
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.1.reg
+    Width: 64
+    Index: 1
+    PseudoName: pseudoreg.1
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.2.reg
+    Width: 64
+    Index: 2
+    PseudoName: pseudoreg.2
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.3.reg
+    Width: 64
+    Index: 3
+    PseudoName: pseudoreg.3
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.4.reg
+    Width: 64
+    Index: 4
+    PseudoName: pseudoreg.4
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.5.reg
+    Width: 64
+    Index: 5
+    PseudoName: pseudoreg.5
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.6.reg
+    Width: 64
+    Index: 6
+    PseudoName: pseudoreg.6
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.7.reg
+    Width: 64
+    Index: 7
+    PseudoName: pseudoreg.7
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.8.reg
+    Width: 64
+    Index: 8
+    PseudoName: pseudoreg.8
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+RegClasses:
+  - RegisterClassName: TEST102.regclass
+    NumRegisters: 16
+    Registers:
+      - TEST102.0.reg
+      - TEST102.1.reg
+      - TEST102.2.reg
+      - TEST102.3.reg
+      - TEST102.4.reg
+      - TEST102.5.reg
+      - TEST102.6.reg
+      - TEST102.7.reg
+      - TEST102.8.reg
+ISAs:
+  - ISAName: TEST102.isa
+InstFormats:
+  - InstFormatName: TEST102.if
+    ISA: TEST102.isa
+    FormatWidth: 8
+    Fields:
+      - FieldName: opcode
+        FieldType: CGInstCode
+        FieldWidth: 4
+        StartBit: 0
+        EndBit: 3
+        MandatoryField: true
+      - FieldName: ra
+        FieldType: CGInstReg
+        FieldWidth: 2
+        StartBit: 4 
+        EndBit: 5
+        MandatoryField: false
+        RegClass: TEST102.regclass
+        RegIsDestination: false
+      - FieldName: rb
+        FieldType: CGInstReg
+        FieldWidth: 2
+        StartBit: 6
+        EndBit: 7
+        MandatoryField: false
+        RegClass: TEST102.regclass
+        RegIsDestination: true 
+  - InstFormatName: TEST102a.if
+    ISA: TEST102.isa
+    FormatWidth: 8
+    Fields:
+      - FieldName: op
+        FieldType: CGInstCode
+        FieldWidth: 4
+        StartBit: 0
+        EndBit: 3
+        MandatoryField: true
+      - FieldName: rsrc
+        FieldType: CGInstReg
+        FieldWidth: 2
+        StartBit: 4 
+        EndBit: 5
+        MandatoryField: false
+        RegClass: TEST102.regclass
+      - FieldName: rdest
+        FieldType: CGInstReg
+        FieldWidth: 2
+        StartBit: 6
+        EndBit: 7
+        MandatoryField: false
+        RegClass: TEST102.regclass
+Cores:
+  - Core: TEST102.core
+    ISA: TEST102.isa
+    RegisterClasses:
+      - RegClass: TEST102.regclass
+    Scheduler: Unknown
+Socs:
+  - Soc: TEST102.soc
+    Cores:
+      - Core: TEST102.core

--- a/test/Yaml/Reader/TEST104.yaml
+++ b/test/Yaml/Reader/TEST104.yaml
@@ -1,0 +1,167 @@
+Registers:
+  - RegName: TEST102.0.reg
+    Width: 64
+    Index: 0
+    PseudoName: pseudoreg.0
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.1.reg
+    Width: 64
+    Index: 1
+    PseudoName: pseudoreg.1
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.2.reg
+    Width: 64
+    Index: 2
+    PseudoName: pseudoreg.2
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.3.reg
+    Width: 64
+    Index: 3
+    PseudoName: pseudoreg.3
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.4.reg
+    Width: 64
+    Index: 4
+    PseudoName: pseudoreg.4
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.5.reg
+    Width: 64
+    Index: 5
+    PseudoName: pseudoreg.5
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.6.reg
+    Width: 64
+    Index: 6
+    PseudoName: pseudoreg.6
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.7.reg
+    Width: 64
+    Index: 7
+    PseudoName: pseudoreg.7
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.8.reg
+    Width: 64
+    Index: 8
+    PseudoName: pseudoreg.8
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+RegClasses:
+  - RegisterClassName: TEST102.regclass
+    NumRegisters: 16
+    Registers:
+      - TEST102.0.reg
+      - TEST102.1.reg
+      - TEST102.2.reg
+      - TEST102.3.reg
+      - TEST102.4.reg
+      - TEST102.5.reg
+      - TEST102.6.reg
+      - TEST102.7.reg
+      - TEST102.8.reg
+ISAs:
+  - ISAName: TEST102.isa
+InstFormats:
+  - InstFormatName: TEST102.if
+    ISA: TEST102.isa
+    FormatWidth: 8
+    Fields:
+      - FieldName: opcode
+        FieldType: CGInstCode
+        FieldWidth: 4
+        StartBit: 0
+        EndBit: 3
+        MandatoryField: true
+      - FieldName: ra
+        FieldType: CGInstReg
+        FieldWidth: 2
+        StartBit: 4 
+        EndBit: 5
+        MandatoryField: false
+        RegClass: TEST102.regclass
+        RegIsDestination: false
+      - FieldName: rb
+        FieldType: CGInstReg
+        FieldWidth: 2
+        StartBit: 6
+        EndBit: 7
+        MandatoryField: false
+        RegClass: TEST102.regclass
+        RegIsDestination: true 
+  - InstFormatName: TEST102a.if
+    ISA: TEST102.isa
+    FormatWidth: 8
+    Fields:
+      - FieldName: op
+        FieldType: CGInstCode
+        FieldWidth: 4
+        StartBit: 0
+        EndBit: 3
+        MandatoryField: true
+      - FieldName: rsrc
+        FieldType: CGInstReg
+        FieldWidth: 2
+        StartBit: 4 
+        EndBit: 5
+        MandatoryField: false
+        RegClass: TEST102.regclass
+      - FieldName: rdest
+        FieldType: CGInstReg
+        FieldWidth: 2
+        StartBit: 6
+        EndBit: 7
+        MandatoryField: false
+        RegClass: TEST102.regclass
+Cores:
+  - Core: TEST102.core
+    ISA: TEST102.isa
+    RegisterClasses:
+      - RegClass: TEST102.regclass
+    Scheduler: PCycle
+Socs:
+  - Soc: TEST102.soc
+    Cores:
+      - Core: TEST102.core

--- a/test/Yaml/Reader/TEST105.yaml
+++ b/test/Yaml/Reader/TEST105.yaml
@@ -1,0 +1,167 @@
+Registers:
+  - RegName: TEST102.0.reg
+    Width: 64
+    Index: 0
+    PseudoName: pseudoreg.0
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.1.reg
+    Width: 64
+    Index: 1
+    PseudoName: pseudoreg.1
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.2.reg
+    Width: 64
+    Index: 2
+    PseudoName: pseudoreg.2
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.3.reg
+    Width: 64
+    Index: 3
+    PseudoName: pseudoreg.3
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.4.reg
+    Width: 64
+    Index: 4
+    PseudoName: pseudoreg.4
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.5.reg
+    Width: 64
+    Index: 5
+    PseudoName: pseudoreg.5
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.6.reg
+    Width: 64
+    Index: 6
+    PseudoName: pseudoreg.6
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.7.reg
+    Width: 64
+    Index: 7
+    PseudoName: pseudoreg.7
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.8.reg
+    Width: 64
+    Index: 8
+    PseudoName: pseudoreg.8
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+RegClasses:
+  - RegisterClassName: TEST102.regclass
+    NumRegisters: 16
+    Registers:
+      - TEST102.0.reg
+      - TEST102.1.reg
+      - TEST102.2.reg
+      - TEST102.3.reg
+      - TEST102.4.reg
+      - TEST102.5.reg
+      - TEST102.6.reg
+      - TEST102.7.reg
+      - TEST102.8.reg
+ISAs:
+  - ISAName: TEST102.isa
+InstFormats:
+  - InstFormatName: TEST102.if
+    ISA: TEST102.isa
+    FormatWidth: 8
+    Fields:
+      - FieldName: opcode
+        FieldType: CGInstCode
+        FieldWidth: 4
+        StartBit: 0
+        EndBit: 3
+        MandatoryField: true
+      - FieldName: ra
+        FieldType: CGInstReg
+        FieldWidth: 2
+        StartBit: 4 
+        EndBit: 5
+        MandatoryField: false
+        RegClass: TEST102.regclass
+        RegIsDestination: false
+      - FieldName: rb
+        FieldType: CGInstReg
+        FieldWidth: 2
+        StartBit: 6
+        EndBit: 7
+        MandatoryField: false
+        RegClass: TEST102.regclass
+        RegIsDestination: true 
+  - InstFormatName: TEST102a.if
+    ISA: TEST102.isa
+    FormatWidth: 8
+    Fields:
+      - FieldName: op
+        FieldType: CGInstCode
+        FieldWidth: 4
+        StartBit: 0
+        EndBit: 3
+        MandatoryField: true
+      - FieldName: rsrc
+        FieldType: CGInstReg
+        FieldWidth: 2
+        StartBit: 4 
+        EndBit: 5
+        MandatoryField: false
+        RegClass: TEST102.regclass
+      - FieldName: rdest
+        FieldType: CGInstReg
+        FieldWidth: 2
+        StartBit: 6
+        EndBit: 7
+        MandatoryField: false
+        RegClass: TEST102.regclass
+Cores:
+  - Core: TEST102.core
+    ISA: TEST102.isa
+    RegisterClasses:
+      - RegClass: TEST102.regclass
+    Scheduler: Pressure
+Socs:
+  - Soc: TEST102.soc
+    Cores:
+      - Core: TEST102.core

--- a/test/Yaml/Reader/TEST106.yaml
+++ b/test/Yaml/Reader/TEST106.yaml
@@ -1,0 +1,167 @@
+Registers:
+  - RegName: TEST102.0.reg
+    Width: 64
+    Index: 0
+    PseudoName: pseudoreg.0
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.1.reg
+    Width: 64
+    Index: 1
+    PseudoName: pseudoreg.1
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.2.reg
+    Width: 64
+    Index: 2
+    PseudoName: pseudoreg.2
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.3.reg
+    Width: 64
+    Index: 3
+    PseudoName: pseudoreg.3
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.4.reg
+    Width: 64
+    Index: 4
+    PseudoName: pseudoreg.4
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.5.reg
+    Width: 64
+    Index: 5
+    PseudoName: pseudoreg.5
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.6.reg
+    Width: 64
+    Index: 6
+    PseudoName: pseudoreg.6
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.7.reg
+    Width: 64
+    Index: 7
+    PseudoName: pseudoreg.7
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+  - RegName: TEST102.8.reg
+    Width: 64
+    Index: 8
+    PseudoName: pseudoreg.8
+    IsFixedValue: false
+    IsSIMD: false
+    RWReg: false
+    ROReg: false
+    CSRReg: true
+    AMSReg: true
+RegClasses:
+  - RegisterClassName: TEST102.regclass
+    NumRegisters: 16
+    Registers:
+      - TEST102.0.reg
+      - TEST102.1.reg
+      - TEST102.2.reg
+      - TEST102.3.reg
+      - TEST102.4.reg
+      - TEST102.5.reg
+      - TEST102.6.reg
+      - TEST102.7.reg
+      - TEST102.8.reg
+ISAs:
+  - ISAName: TEST102.isa
+InstFormats:
+  - InstFormatName: TEST102.if
+    ISA: TEST102.isa
+    FormatWidth: 8
+    Fields:
+      - FieldName: opcode
+        FieldType: CGInstCode
+        FieldWidth: 4
+        StartBit: 0
+        EndBit: 3
+        MandatoryField: true
+      - FieldName: ra
+        FieldType: CGInstReg
+        FieldWidth: 2
+        StartBit: 4 
+        EndBit: 5
+        MandatoryField: false
+        RegClass: TEST102.regclass
+        RegIsDestination: false
+      - FieldName: rb
+        FieldType: CGInstReg
+        FieldWidth: 2
+        StartBit: 6
+        EndBit: 7
+        MandatoryField: false
+        RegClass: TEST102.regclass
+        RegIsDestination: true 
+  - InstFormatName: TEST102a.if
+    ISA: TEST102.isa
+    FormatWidth: 8
+    Fields:
+      - FieldName: op
+        FieldType: CGInstCode
+        FieldWidth: 4
+        StartBit: 0
+        EndBit: 3
+        MandatoryField: true
+      - FieldName: rsrc
+        FieldType: CGInstReg
+        FieldWidth: 2
+        StartBit: 4 
+        EndBit: 5
+        MandatoryField: false
+        RegClass: TEST102.regclass
+      - FieldName: rdest
+        FieldType: CGInstReg
+        FieldWidth: 2
+        StartBit: 6
+        EndBit: 7
+        MandatoryField: false
+        RegClass: TEST102.regclass
+Cores:
+  - Core: TEST102.core
+    ISA: TEST102.isa
+    RegisterClasses:
+      - RegClass: TEST102.regclass
+    Scheduler: Programmatic
+Socs:
+  - Soc: TEST102.soc
+    Cores:
+      - Core: TEST102.core

--- a/test/Yaml/Reader/yaml_reader_test_103.cpp
+++ b/test/Yaml/Reader/yaml_reader_test_103.cpp
@@ -1,0 +1,37 @@
+//
+// _YAML_READER_TEST103_CPP_
+//
+// Copyright (C) 2017-2020 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+// 
+//
+
+#include <iostream>
+#include "CoreGen/CoreGenBackend/CoreGenBackend.h"
+
+std::string PROJNAME = "TEST103";
+std::string PROJROOT = "./";
+std::string ARCHROOT = "./";
+std::string PROJYAML = "../TEST103.yaml";
+
+int main( int argc, char **argv ){
+  CoreGenBackend *CG = new CoreGenBackend(PROJNAME,
+                                          PROJROOT,
+                                          ARCHROOT);
+  if( !CG ){
+    std::cout << "ERROR : FAILED TO CREATE COREGEN OBJECT" << std::endl;
+    return -1;
+  }
+
+  if( !CG->ReadIR( PROJYAML ) ){
+    std::cout << "ERROR : FAILED TO READ YAML IR:" << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  delete CG;
+  return 0;
+}

--- a/test/Yaml/Reader/yaml_reader_test_104.cpp
+++ b/test/Yaml/Reader/yaml_reader_test_104.cpp
@@ -1,0 +1,37 @@
+//
+// _YAML_READER_TEST104_CPP_
+//
+// Copyright (C) 2017-2020 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+// 
+//
+
+#include <iostream>
+#include "CoreGen/CoreGenBackend/CoreGenBackend.h"
+
+std::string PROJNAME = "TEST104";
+std::string PROJROOT = "./";
+std::string ARCHROOT = "./";
+std::string PROJYAML = "../TEST104.yaml";
+
+int main( int argc, char **argv ){
+  CoreGenBackend *CG = new CoreGenBackend(PROJNAME,
+                                          PROJROOT,
+                                          ARCHROOT);
+  if( !CG ){
+    std::cout << "ERROR : FAILED TO CREATE COREGEN OBJECT" << std::endl;
+    return -1;
+  }
+
+  if( !CG->ReadIR( PROJYAML ) ){
+    std::cout << "ERROR : FAILED TO READ YAML IR:" << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  delete CG;
+  return 0;
+}

--- a/test/Yaml/Reader/yaml_reader_test_105.cpp
+++ b/test/Yaml/Reader/yaml_reader_test_105.cpp
@@ -1,0 +1,37 @@
+//
+// _YAML_READER_TEST105_CPP_
+//
+// Copyright (C) 2017-2020 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+//
+
+#include <iostream>
+#include "CoreGen/CoreGenBackend/CoreGenBackend.h"
+
+std::string PROJNAME = "TEST105";
+std::string PROJROOT = "./";
+std::string ARCHROOT = "./";
+std::string PROJYAML = "../TEST105.yaml";
+
+int main( int argc, char **argv ){
+  CoreGenBackend *CG = new CoreGenBackend(PROJNAME,
+                                          PROJROOT,
+                                          ARCHROOT);
+  if( !CG ){
+    std::cout << "ERROR : FAILED TO CREATE COREGEN OBJECT" << std::endl;
+    return -1;
+  }
+
+  if( !CG->ReadIR( PROJYAML ) ){
+    std::cout << "ERROR : FAILED TO READ YAML IR:" << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  delete CG;
+  return 0;
+}

--- a/test/Yaml/Reader/yaml_reader_test_106.cpp
+++ b/test/Yaml/Reader/yaml_reader_test_106.cpp
@@ -1,0 +1,37 @@
+//
+// _YAML_READER_TEST106_CPP_
+//
+// Copyright (C) 2017-2020 Tactical Computing Laboratories, LLC
+// All Rights Reserved
+// contact@tactcomplabs.com
+//
+// See LICENSE in the top level directory for licensing details
+//
+//
+
+#include <iostream>
+#include "CoreGen/CoreGenBackend/CoreGenBackend.h"
+
+std::string PROJNAME = "TEST106";
+std::string PROJROOT = "./";
+std::string ARCHROOT = "./";
+std::string PROJYAML = "../TEST106.yaml";
+
+int main( int argc, char **argv ){
+  CoreGenBackend *CG = new CoreGenBackend(PROJNAME,
+                                          PROJROOT,
+                                          ARCHROOT);
+  if( !CG ){
+    std::cout << "ERROR : FAILED TO CREATE COREGEN OBJECT" << std::endl;
+    return -1;
+  }
+
+  if( !CG->ReadIR( PROJYAML ) ){
+    std::cout << "ERROR : FAILED TO READ YAML IR:" << CG->GetErrStr() << std::endl;
+    delete CG;
+    return -1;
+  }
+
+  delete CG;
+  return 0;
+}


### PR DESCRIPTION
This adds the initial parameter support for SMT scheduler types into the CoreGenCore node.  This also adds support for testing the relationship between thread units and SMT schedulers in the CoreSafetyPass.  

Issue #260 Issue #259 