### PR TITLE
Added overhead percent handling

### DIFF
--- a/include/CoreGen/Poar/PoarConfig.h
+++ b/include/CoreGen/Poar/PoarConfig.h
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <string>
 #include <fstream>
+#include <vector>
 
 #include "yaml-cpp/yaml.h"
 
@@ -66,17 +67,16 @@ public:
   }PassType;
 
   typedef struct{
-    ConfigType Type;    ///< ConfigEntry: configuration type
-    ValueType VType;    ///< ConfigEntry: power or area value
-    PassType PType;     ///< ConfigEntry: CoreGen or StoneCutter pass
-    std::string Name;   ///< ConfigEntry: name of the config entry
-    std::string Accum;  ///< ConfigEntry: name of the corresponding accumulator
-    double DefaultVal;  ///< ConfigEntry: default value
-    double Value;       ///< ConfigEntry: the value of the entry
-    double Result;      ///< ConfigEntry: the resulting accumulated value
-  }ConfigEntry;         ///< PoarConfig: configuration entry structure
-
-
+    ConfigType Type;        ///< ConfigEntry: configuration type
+    ValueType VType;        ///< ConfigEntry: power or area value
+    PassType PType;         ///< ConfigEntry: CoreGen or StoneCutter pass
+    std::string Name;       ///< ConfigEntry: name of the config entry
+    std::string Accum;      ///< ConfigEntry: name of the corresponding accumulator
+    double DefaultVal;      ///< ConfigEntry: default value
+    double Value;           ///< ConfigEntry: the value of the entry
+    double Result;          ///< ConfigEntry: the resulting accumulated value
+    double AdjustedResult;  ///< ConfigEntry; the accumulated value post any adjustments
+  }ConfigEntry;             ///< PoarConfig: configuration entry structure
 
 private:
   std::string Config;   ///< PoarConfig: configuration file path
@@ -109,7 +109,8 @@ public:
   unsigned GetNumEntry();
 
   /// PoarConfig: set the resulting value for the target entry
-  bool SetResult(unsigned Entry, uint64_t Width);
+  bool SetResult(unsigned Entry, uint64_t Width, std::vector<double> MultiplierVect);
+
 };
 
 #endif

--- a/include/CoreGen/Poar/PoarIO.h
+++ b/include/CoreGen/Poar/PoarIO.h
@@ -26,6 +26,7 @@
 #include <iostream>
 #include <iomanip>
 #include <fstream>
+#include <bits/stdc++.h>
 
 //-- Yaml headers
 #include "yaml-cpp/yaml.h"
@@ -63,8 +64,14 @@ private:
   /// PoarIO: Get the total power
   double GetTotalPower();
 
+  /// PoarIO: Get the total power before multipliers were applied
+  double GetTotalUnadjustedPower();
+  
   /// PoarIO: Get the total area
   double GetTotalArea();
+
+  /// PoarIO: Get the total area before multipliers were applied
+  double GetTotalUnadjustedArea();
 
   /// PoarIO: Write the LaTeX makefile
   bool WriteLatexMakefile();

--- a/include/CoreGen/Poar/PoarOpts.h
+++ b/include/CoreGen/Poar/PoarOpts.h
@@ -22,6 +22,7 @@
 
 #include <iostream>
 #include <string>
+#include <vector>
 
 #ifndef POAR_MAJOR_VERSION
 #define POAR_MAJOR_VERSION 0
@@ -38,18 +39,19 @@
 class PoarOpts{
 private:
   // private variables
-  int argc;             ///< PoarOpts: ARGC command line info
-  char **argv;          ///< PoarOpts: ARGV command line info
-  std::string YamlFile; ///< PoarOpts: Yaml input file
-  std::string SCFile;   ///< PoarOpts: Signal map input file
-  std::string Config;   ///< PoarOpts: configuration file
-  std::string OutFile;  ///< PoarOpts: output files
-  std::string Root;     ///< PoarOpts: root node for the graph traversal
+  int argc;                             ///< PoarOpts: ARGC command line info
+  char **argv;                          ///< PoarOpts: ARGV command line info
+  std::string YamlFile;                 ///< PoarOpts: Yaml input file
+  std::string SCFile;                   ///< PoarOpts: Signal map input file
+  std::string Config;                   ///< PoarOpts: configuration file
+  std::string OutFile;                  ///< PoarOpts: output files
+  std::string Root;                     ///< PoarOpts: root node for the graph traversal
 
-  bool TextOutput;      ///< PoarOpts: defines textual output
-  bool YamlOutput;      ///< PoarOpts: defines yaml output
-  bool LatexOutput;     ///< PoarOpts: defines latex output
-  bool XmlOutput;       ///< PoarOpts: defines xml output
+  bool TextOutput;                      ///< PoarOpts: defines textual output
+  bool YamlOutput;                      ///< PoarOpts: defines yaml output
+  bool LatexOutput;                     ///< PoarOpts: defines latex output
+  bool XmlOutput;                       ///< PoarOpts: defines xml output
+  std::vector<double> MultiplierVect;   ///< PoarOpts: any multipliers to be applied (ie. Overhead Percent)
 
   // private functions
 
@@ -92,6 +94,9 @@ public:
 
   /// PoarOpts: Retrieves the signal map input file
   std::string GetSigMapFile() { return SCFile; }
+
+  /// PoarOpts: Retrieves the vector of multipliers to be applied (ie. overhead percentage)
+  std::vector<double> GetMultiplierVect() { return MultiplierVect; }
 
   /// PoarOpts: Retrieves the root node for the graph traversal
   std::string GetRoot() { return Root; }

--- a/src/Poar/PoarConfig.cpp
+++ b/src/Poar/PoarConfig.cpp
@@ -70,13 +70,16 @@ PoarConfig::PoarConfig(std::string C)
 PoarConfig::~PoarConfig(){
 }
 
-bool PoarConfig::SetResult(unsigned Entry, uint64_t Width){
+bool PoarConfig::SetResult(unsigned Entry, uint64_t Width, std::vector<double> MultiplierVect){
   unsigned i=0;
   bool done = false;
   while( !done ){
-
     if( i == Entry ){
       Entries[i].Result = Entries[i].Value * (double)(Width);
+      double TotalMultipliers = 1;
+      for( unsigned j=0; j<MultiplierVect.size(); j++ )
+        TotalMultipliers += MultiplierVect[j];
+      Entries[i].AdjustedResult = Entries[i].Result * TotalMultipliers;
       return true;
     }
 

--- a/src/Poar/PoarData.cpp
+++ b/src/Poar/PoarData.cpp
@@ -132,7 +132,7 @@ bool PoarData::DeriveData(){
       // execute the accumulator
       if( (PA != nullptr) && (CE.PType == PoarConfig::PoarCG) ){
         PA->Accum();
-        PConfig->SetResult(i,PA->GetWidth());
+        PConfig->SetResult(i,PA->GetWidth(), POpts->GetMultiplierVect());
       }
     }
   }
@@ -149,11 +149,10 @@ bool PoarData::DeriveData(){
       // execute the accumulator
       if( (PA != nullptr) && (CE.PType == PoarConfig::PoarSM) ){
         PA->Accum();
-        PConfig->SetResult(i,PA->GetWidth());
+        PConfig->SetResult(i,PA->GetWidth(), POpts->GetMultiplierVect());
+        }
       }
     }
-  }
-
   return true;
 }
 

--- a/src/Poar/PoarIO.cpp
+++ b/src/Poar/PoarIO.cpp
@@ -25,6 +25,20 @@ double PoarIO::GetTotalPower(){
 
     if( (CE.VType == PoarConfig::PoarPower) &&
         (CE.Type  != PoarConfig::UNK_ENTRY) ){
+      result += CE.AdjustedResult;
+    }
+  }
+  return result;
+}
+
+double PoarIO::GetTotalUnadjustedPower(){
+  double result = 0.;
+  for( unsigned i=0; i<PConfig->GetNumEntry(); i++ ){
+    // retrieve the i'th entry
+    PoarConfig::ConfigEntry CE = PConfig->GetEntry(i);
+
+    if( (CE.VType == PoarConfig::PoarPower) &&
+        (CE.Type  != PoarConfig::UNK_ENTRY) ){
       result += CE.Result;
     }
   }
@@ -32,6 +46,20 @@ double PoarIO::GetTotalPower(){
 }
 
 double PoarIO::GetTotalArea(){
+  double result = 0.;
+  for( unsigned i=0; i<PConfig->GetNumEntry(); i++ ){
+    // retrieve the i'th entry
+    PoarConfig::ConfigEntry CE = PConfig->GetEntry(i);
+
+    if( (CE.VType == PoarConfig::PoarArea) &&
+        (CE.Type  != PoarConfig::UNK_ENTRY) ){
+      result += CE.AdjustedResult;
+    }
+  }
+  return result;
+}
+
+double PoarIO::GetTotalUnadjustedArea(){
   double result = 0.;
   for( unsigned i=0; i<PConfig->GetNumEntry(); i++ ){
     // retrieve the i'th entry
@@ -59,7 +87,7 @@ bool PoarIO::WriteText(){
         (CE.Type  != PoarConfig::UNK_ENTRY) ){
       std::cout << " - " << CE.Name;
       CGPrintSpace(CE.Name.length(),20);
-      std::cout << CE.Result << " mW" << std::endl;
+      std::cout << CE.AdjustedResult << " mW" << std::endl;
     }
   }
   std::cout << "-----------------------------------------------------------------" << std::endl;
@@ -74,7 +102,7 @@ bool PoarIO::WriteText(){
         (CE.Type  != PoarConfig::UNK_ENTRY) ){
       std::cout << " - " << CE.Name;
       CGPrintSpace(CE.Name.length(),20);
-      std::cout << CE.Result << " gates" << std::endl;
+      std::cout << CE.AdjustedResult << " gates" << std::endl;
     }
   }
   std::cout << "-----------------------------------------------------------------" << std::endl;
@@ -118,7 +146,7 @@ bool PoarIO::WriteYaml(){
     if( (CE.VType == PoarConfig::PoarArea) &&
         (CE.Type  != PoarConfig::UNK_ENTRY) ){
       out << YAML::BeginMap;
-      out << YAML::Key << CE.Name << YAML::Value << CE.Result;
+      out << YAML::Key << CE.Name << YAML::Value << CE.AdjustedResult;
       out << YAML::EndMap;
     }
   }
@@ -134,7 +162,7 @@ bool PoarIO::WriteYaml(){
     if( (CE.VType == PoarConfig::PoarPower) &&
         (CE.Type  != PoarConfig::UNK_ENTRY) ){
       out << YAML::BeginMap;
-      out << YAML::Key << CE.Name << YAML::Value << CE.Result;
+      out << YAML::Key << CE.Name << YAML::Value << CE.AdjustedResult;
       out << YAML::EndMap;
     }
   }
@@ -170,7 +198,7 @@ bool PoarIO::WriteXML(){
     if( (CE.VType == PoarConfig::PoarArea) &&
         (CE.Type  != PoarConfig::UNK_ENTRY) ){
       Out << "\t\t<" << CE.Name << ">"
-          << CE.Result
+          << CE.AdjustedResult
           << "</" << CE.Name << ">" << std::endl;
     }
   }
@@ -183,7 +211,7 @@ bool PoarIO::WriteXML(){
     if( (CE.VType == PoarConfig::PoarPower) &&
         (CE.Type  != PoarConfig::UNK_ENTRY) ){
       Out << "\t\t<" << CE.Name << ">"
-          << CE.Result
+          << CE.AdjustedResult
           << "</" << CE.Name << ">" << std::endl;
     }
   }
@@ -397,7 +425,7 @@ bool PoarIO::WriteLatexTexfile(){
 
     if( (CE.VType == PoarConfig::PoarArea) &&
         (CE.Type  != PoarConfig::UNK_ENTRY) ){
-      ofs << "\\texttt{" << EscapeUnderscore(CE.Name) << "} & " << CE.Result << " gates \\\\" << std::endl;
+      ofs << "\\texttt{" << EscapeUnderscore(CE.Name) << "} & " << CE.AdjustedResult << " gates \\\\" << std::endl;
       ofs << "\\hline" << std::endl;
     }
   }
@@ -425,7 +453,7 @@ bool PoarIO::WriteLatexTexfile(){
 
     if( (CE.VType == PoarConfig::PoarPower) &&
         (CE.Type  != PoarConfig::UNK_ENTRY) ){
-      ofs << "\\texttt{" << EscapeUnderscore(CE.Name) << "} & " << CE.Result << " mW \\\\" << std::endl;
+      ofs << "\\texttt{" << EscapeUnderscore(CE.Name) << "} & " << CE.AdjustedResult << " mW \\\\" << std::endl;
       ofs << "\\hline" << std::endl;
     }
   }

--- a/src/Poar/PoarOpts.cpp
+++ b/src/Poar/PoarOpts.cpp
@@ -38,6 +38,7 @@ void PoarOpts::PrintHelp(){
   std::cout << "Input Files:" << std::endl;
   std::cout << "\t--design /path/to/design.yaml       : Set the CoreGen design input file" << std::endl;
   std::cout << "\t--sigmap /path/to/sigmap.yaml       : Set the StoneCutter signal map" << std::endl;
+  std::cout << "\t--overhead CONSTANT                 : Set constant routing/wire congestion overhead" << std::endl;
   std::cout << std::endl;
   std::cout << "Output Formats:" << std::endl;
   std::cout << "\t--text                              : Text output (default)" << std::endl;
@@ -110,7 +111,17 @@ bool PoarOpts::ParseOpts(bool *isHelp){
       std::string S(argv[i+1]);
       SCFile = S;
       i++;
-    }else if( s=="--text" ){
+    }else if( s=="--overhead") {
+      if( i+1 > (argc-1) ){
+        std::cout << "Error : --overhead requires an argument" << std::endl;
+        return false;
+      }
+      std::string S(argv[i+1]);
+      unsigned N = std::stoul(S);
+      MultiplierVect.push_back((double)(N * 0.01));
+      i++;
+    }
+    else if( s=="--text" ){
       TextOutput = true;
       YamlOutput = false;
       LatexOutput = false;


### PR DESCRIPTION
- Added support for multipliers (ie. Overhead percentage)
- Future multipliers to be supported can do so by adding necessary handlers in POpts.cpp and pushing back the value to MultipliersVect 
- Config Entries continue to have a .Result field and this will remain the value calculated before multipliers
- Config Entries now have an AdjustedResult field which is what is actually output in PoarIO (Default Multiplier of 1 will be applied when no overhead or anything similar is accounted for)