### PR TITLE
Issues 322, 323

### DIFF
--- a/include/CoreGen/StoneCutter/SCParser.h
+++ b/include/CoreGen/StoneCutter/SCParser.h
@@ -31,6 +31,8 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <numeric>
+#include <string>
 
 // CoreGen headers
 #include "CoreGen/StoneCutter/SCLexer.h"

--- a/include/CoreGen/StoneCutter/SCUtil.h
+++ b/include/CoreGen/StoneCutter/SCUtil.h
@@ -40,48 +40,56 @@ using namespace llvm;
 
 /** VarAttrs struct: contains the potential parameters for variable attributes */
 typedef struct{
-  unsigned width;   ///< VarAttrs: width of the variable or register
-  unsigned elems;   ///< VarAttrs: number of elements in the variable
-  unsigned elems2D; ///< VarAttrx: number of elements in the variable if matrix
-  bool defSign;     ///< VarAtrrs: is the variable a signed integer
-  bool defVector;   ///< VarAttrs: is the variable a vector (elems > 1)
-  bool defMatrix;   ///< VarAttrs: is the variable a matrix (elems2D > 0)
-  bool defFloat;    ///< VarAttrs: is the variable a floating point variable
-  bool defRegClass; ///< VarAttrs: does the variable represent a register class
-  bool defReadOnly; ///< VarAttrs: read-only register
-  bool defReadWrite;///< VarAttrs: read-write register
-  bool defCSR;      ///< VarAttrs: CSR register
-  bool defAMS;      ///< VarAttrs: AMS register
-  bool defTUS;      ///< VarAttrs: Thread unit shared register
-  bool defShared;   ///< VarAttrs: Shared register
+  unsigned width;          ///< VarAttrs: width of the variable or register
+  unsigned elems;          ///< VarAttrs: number of elements in the variable
+  unsigned elems2D;        ///< VarAttrx: number of elements in the variable if matrix
+  bool defSign;            ///< VarAtrrs: is the variable a signed integer
+  bool defVector;          ///< VarAttrs: is the variable a vector (elems > 1)
+  bool defFloat;           ///< VarAttrs: is the variable a floating point variable
+  unsigned xIdx;           ///< VarAttrs: is the X index for a register within a vector/matrix element
+  unsigned yIdx;           ///< VarAttrs: is the Y index for a register within a vector/matrix element
+  bool defMatrix;          ///< VarAttrs: is the variable a matrix (elems2D > 0)
+  bool defElem;          ///< VarAttrs: is the variable in a vect/mat
+  bool defRegClass;        ///< VarAttrs: does the variable represent a register class
+  bool defReadOnly;        ///< VarAttrs: read-only register
+  bool defReadWrite;       ///< VarAttrs: read-write register
+  bool defCSR;             ///< VarAttrs: CSR register
+  bool defAMS;             ///< VarAttrs: AMS register
+  bool defTUS;             ///< VarAttrs: Thread unit shared register
+  bool defShared;          ///< VarAttrs: Shared register
+  std::string containers;  ///< VarAttrs: name of containing vect/matrix if applicable 
 }VarAttrs;
 
 /** VarAttrEntry struct: contains a single element for the VarAttrEntryTable */
 typedef struct{
-  std::string Name;   ///< VarAttrEntry: base name of the datatype
-  unsigned width;     ///< VarAttrEntry: width of the type in bits
-  unsigned elems;     ///< VarAttrEntry: number of elements in the type's X-dimesion
-  unsigned elems2D;   ///< VarAttrEntry: number of elements in the type's Y-dimension
-  bool IsDefSign;     ///< VarAttrEntry: is the type a signed integer
-  bool IsDefVector;   ///< VarAttrEntry: is the type a vector (elems > 1)
-  bool IsDefMatrix;   ///< VarAttrEntry: is the type a matrix (elems2D > 0)
-  bool IsDefFloat;    ///< VarAttrEntry: is the type a floating point
+  std::string Name;       ///< VarAttrEntry: base name of the datatype
+  unsigned width;         ///< VarAttrEntry: width of the type in bits
+  unsigned elems;         ///< VarAttrEntry: number of elements in the type's X-dimesion
+  bool IsDefSign;         ///< VarAttrEntry: is the type a signed integer
+  bool IsDefVector;       ///< VarAttrEntry: is the type a vector (elems > 1)
+  bool IsDefFloat;        ///< VarAttrEntry: is the type a floating point
+  bool IsDefMatrix;       ///< VarAttrEntry: is the type a matrix (elems2D > 0)
+  bool IsDefElem;         ///< VarAttrEntry: is this an element of a vector/matrix
+  unsigned elems2D;       ///< VarAttrEntry: number of elements in the type's Y-dimension
+  int xIdx;          ///< VarAttrs: is the X index for a register within a vector/matrix element
+  int yIdx;          ///< VarAttrs: is the Y index for a register within a vector/matrix element
+  std::vector<std::string> containers;  ///< VarAttrs: name of containing vectors/matrix if applicable 
 }VarAttrEntry;
 
 /** Contains a list of commonly found datatypes in StoneCutter */
 const VarAttrEntry VarAttrEntryTable[] = {
-  { "float",  32, 1, false, false, true },
-  { "double", 64, 1, false, false, true },
-  { "bool",    1, 1, false, false, false },
-  { "u8",      8, 1, false, false, false },
-  { "u16",    16, 1, false, false, false },
-  { "u32",    32, 1, false, false, false },
-  { "u64",    64, 1, false, false, false },
-  { "s8",      8, 1, true,  false, false },
-  { "s16",    16, 1, true,  false, false },
-  { "s32",    32, 1, true,  false, false },
-  { "s64",    32, 1, true,  false, false },
-  { ".",       0, 0, false, false, false }  // disable flag
+  { "float",  32, 1, false, false, true, false, false, 2, -1, -1}, 
+  { "double", 64, 1, false, false, true, false, false, 2, -1, -1}, 
+  { "bool",    1, 1, false, false, false, false, false, 2, -1, -1}, 
+  { "u8",      8, 1, false, false, false, false, false, 2, -1, -1}, 
+  { "u16",    16, 1, false, false, false, false, false, 2, -1, -1}, 
+  { "u32",    32, 1, false, false, false, false, false, 2, -1, -1}, 
+  { "u64",    64, 1, false, false, false, false, false, 2, -1, -1}, 
+  { "s8",      8, 1, true,  false, false, false, false, 2, -1, -1}, 
+  { "s16",    16, 1, true,  false, false, false, false, 2, -1, -1}, 
+  { "s32",    32, 1, true,  false, false, false, false, 2, -1, -1}, 
+  { "s64",    32, 1, true,  false, false, false, false, 2, -1, -1}, 
+  { ".",       0, 0, false, false, false, false, false, 2, -1, -1}  // disable flag
 };
 
 /** Contains a list of pipeline attributes */

--- a/src/StoneCutter/SCParser.cpp
+++ b/src/StoneCutter/SCParser.cpp
@@ -1531,14 +1531,7 @@ std::unique_ptr<RegClassAST> SCParser::ParseRegClassDef(){
             for( unsigned i=0; i<ArgAttrs[L_VAttr].elems; i++ ){
               for( unsigned j=0; j<ArgAttrs[L_VAttr].elems2D; j++ ){
                 std::string MatElemName = RegName + "_row" + std::to_string(i) + "_col" + std::to_string(j);
-                VarAttrs MatElemAttrs;
-                // init the register attrs
-                MatElemAttrs.defReadOnly   = false;
-                MatElemAttrs.defReadWrite  = true;  // default to true
-                MatElemAttrs.defCSR        = false;
-                MatElemAttrs.defAMS        = false;
-                MatElemAttrs.defTUS        = false;
-                MatElemAttrs.defShared     = false;
+                VarAttrs MatElemAttrs = ArgAttrs[L_VAttr];
                 MatElemAttrs.defMatrix     = true;
                 MatElemAttrs.defElem       = true;
                 MatElemAttrs.defVector     = false;

--- a/test/StoneCutter/Parser/KnownPass/sc_parser_test148.sc
+++ b/test/StoneCutter/Parser/KnownPass/sc_parser_test148.sc
@@ -1,6 +1,6 @@
 #-- sc_parser_test148.sc
 
-regclass foo( u8 r1<9999999999999> )
+regclass foo( u8 r1<889> )
 
 def foo(n){
   n = n+1


### PR DESCRIPTION
- Added full expansion for the vec parsing support inside RegClass
- Added full expansion for the mat parsing support inside RegClass
- Ensured whole vector is still accessible after expansion instead of just individual elements
- For matrices, all row and column vectors are preserved 
- If matrix is square, then a diagonal vector is also preserved 