### PR TITLE
fixing memory deallocation in VLIWPipeBuilder

### DIFF
--- a/src/StoneCutter/Passes/SCVLIWPipeBuilder.cpp
+++ b/src/StoneCutter/Passes/SCVLIWPipeBuilder.cpp
@@ -14,7 +14,7 @@
 SCVLIWPipeBuilder::SCVLIWPipeBuilder(Module *TM,
                      SCOpts *O,
                      SCMsg *M)
-  : SCPass("VLIWPipeBuilder","",TM,O,M) {
+  : SCPass("VLIWPipeBuilder","",TM,O,M), SigMap(nullptr), Graph(nullptr) {
 }
 
 SCVLIWPipeBuilder::~SCVLIWPipeBuilder(){


### PR DESCRIPTION
fixing bug in incorrectly freeing the graph structure in VLIWPipeBuilder when no graph was present